### PR TITLE
fix: request blocked papers in reports

### DIFF
--- a/src/research_lab/report.py
+++ b/src/research_lab/report.py
@@ -142,7 +142,7 @@ def _needs_user_article(candidate: PaperCandidate) -> bool:
     return (
         candidate.document_kind == "paper"
         and not candidate.full_text
-        and candidate.access_status in {"paywalled", "abstract_only"}
+        and candidate.access_status in {"paywalled", "abstract_only", "unreadable"}
         and candidate.score >= 0.45
     )
 
@@ -160,7 +160,7 @@ def _render_article_request(candidate: PaperCandidate) -> list[str]:
         meta.append(f"access={candidate.access_status}")
     if meta:
         lines.append(f"  - {' | '.join(meta)}")
-    lines.append("  - why request: the run could only reach a landing page or abstract, so your university access could unlock full-text evidence.")
+    lines.append("  - why request: the run could only reach a blocked, thin, or unreadable page, so your university access could unlock full-text evidence.")
     if candidate.reasons:
         lines.append(f"  - relevance: {', '.join(candidate.reasons[:4])}")
     return lines

--- a/src/research_lab/sources.py
+++ b/src/research_lab/sources.py
@@ -314,23 +314,33 @@ def _extract_year(text: str) -> int | None:
 def _parse_scholar_authors(metadata: str) -> list[str]:
     if not metadata:
         return []
-    prefix = metadata.split(" - ", 1)[0]
+    prefix = _split_scholar_metadata(metadata)[0]
     authors: list[str] = []
     for item in prefix.split(","):
-        cleaned = item.strip()
-        if cleaned and cleaned not in {"...", "…"}:
+        cleaned = item.strip().rstrip(". …")
+        if cleaned and cleaned not in {"...", "…"} and not re.fullmatch(r"(19|20)\d{2}", cleaned):
             authors.append(cleaned)
     return authors[:6]
 
 
 def _parse_scholar_venue(metadata: str, year: int | None) -> str:
-    parts = [part.strip() for part in metadata.split(" - ") if part.strip()]
+    parts = _split_scholar_metadata(metadata)
     if len(parts) < 2:
         return ""
     venue = parts[1]
     if year is not None:
         venue = venue.replace(str(year), "").strip(" ,")
     return venue
+
+
+def _split_scholar_metadata(metadata: str) -> list[str]:
+    parts = [part.strip(" ,") for part in re.split(r"\s*[\u2013\u2014-]\s+", metadata) if part.strip(" ,")]
+    return parts or [metadata.strip()]
+
+
+def _clean_scholar_title(title: str) -> str:
+    cleaned = re.sub(r"^(?:\[(?:HTML|PDF|BOOK|CITATION)\])+\s*", "", title, flags=re.IGNORECASE)
+    return _clean_text(cleaned)
 
 
 def _looks_like_paywall(text: str) -> bool:
@@ -360,6 +370,13 @@ def _looks_like_full_text(text: str) -> bool:
         if re.search(rf"\b{marker}\b", text)
     )
     return section_hits >= 3 or (section_hits >= 2 and len(text) >= 5000)
+
+
+def _classify_fetch_error(url: str, exc: SourceError) -> FullTextResult:
+    message = str(exc)
+    if any(code in message for code in ["HTTP Error 401", "HTTP Error 403", "HTTP Error 451"]):
+        return FullTextResult(text="", source="", access_status="paywalled", access_url=url)
+    return FullTextResult(text="", source="", access_status="unreadable", access_url=url)
 
 
 def _classify_html_access(candidate: PaperCandidate, response: HttpResponse) -> FullTextResult:
@@ -457,7 +474,7 @@ def search_google_scholar(
         year = _extract_year(item["meta"])
         results.append(
             PaperCandidate(
-                title=item["title"],
+                title=_clean_scholar_title(item["title"]),
                 abstract=item["snippet"],
                 url=item["url"],
                 source="googlescholar",
@@ -684,6 +701,7 @@ def fetch_candidate_full_text(candidate: PaperCandidate, client: HttpClient) -> 
         try:
             response = client.fetch(url, headers={"Accept": "text/html,application/pdf;q=0.9,*/*;q=0.8"})
         except SourceError as exc:
+            last_result = _classify_fetch_error(url, exc)
             last_error = exc
             continue
         content_type = response.content_type.lower()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -38,6 +38,32 @@ class ReportTests(unittest.TestCase):
             self.assertIn("Paywalled Adaptation Paper", report)
             self.assertIn("why request", report)
 
+    def test_write_run_files_requests_unreadable_high_score_paper(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_dir = Path(tmpdir)
+            brief = ResearchBrief(topic="graph neural networks", context="notes")
+            candidate = PaperCandidate(
+                title="Unreadable But Relevant Paper",
+                abstract="Strong metadata but no readable page.",
+                url="https://example.com/paper",
+                source="semanticscholar",
+                source_id="s2:paper",
+                year=2024,
+                venue="Bioinformatics",
+                source_names=["semanticscholar"],
+                score=0.91,
+                reasons=["topic overlap 4/4", "has abstract"],
+                access_status="unreadable",
+                access_url="https://example.com/paper",
+            )
+            artifacts = RunArtifacts.create("run-2", str(run_dir), brief, [], [candidate], "program")
+
+            write_run_files(run_dir, artifacts)
+
+            report = (run_dir / "report.md").read_text(encoding="utf-8")
+            self.assertIn("Unreadable But Relevant Paper", report)
+            self.assertIn("access=unreadable", report)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from research_lab.models import PaperCandidate
 from research_lab.sources import (
     HttpResponse,
+    SourceError,
     _decode_duckduckgo_url,
     _extract_text_from_html,
     fetch_candidate_full_text,
@@ -92,8 +93,8 @@ class SourceHelpersTests(unittest.TestCase):
               <div class='gs_or_ggsm'><a href='https://example.com/paper.pdf'>[PDF]</a></div>
             </div>
             <div class='gs_ri'>
-              <h3 class='gs_rt'><a href='https://example.com/paper'>Test-Time Adaptation for Language Models</a></h3>
-              <div class='gs_a'>Jane Doe, John Roe - Journal of Testing, 2024</div>
+              <h3 class='gs_rt'><a href='https://example.com/paper'>[HTML][HTML] Test-Time Adaptation for Language Models</a></h3>
+              <div class='gs_a'>Jane Doe, John Roe...- Journal of Testing, 2024 - Example Publisher</div>
               <div class='gs_rs'>A strong paper about inference-time adaptation.</div>
             </div>
           </div>
@@ -113,8 +114,10 @@ class SourceHelpersTests(unittest.TestCase):
 
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].source, "googlescholar")
+        self.assertEqual(results[0].title, "Test-Time Adaptation for Language Models")
         self.assertEqual(results[0].authors, ["Jane Doe", "John Roe"])
         self.assertEqual(results[0].year, 2024)
+        self.assertEqual(results[0].venue, "Journal of Testing")
         self.assertEqual(results[0].open_access_url, "https://example.com/paper.pdf")
 
     def test_fetch_candidate_full_text_marks_abstract_only_paper(self) -> None:
@@ -148,6 +151,27 @@ class SourceHelpersTests(unittest.TestCase):
 
         self.assertEqual(result.access_status, "abstract_only")
         self.assertEqual(result.text, "")
+
+    def test_fetch_candidate_full_text_marks_403_as_paywalled(self) -> None:
+        candidate = PaperCandidate(
+            title="Blocked Paper",
+            abstract="",
+            url="https://example.com/paywalled",
+            source="openalex",
+            source_id="oa:blocked",
+            document_kind="paper",
+            source_names=["openalex"],
+        )
+
+        class _FailingClient:
+            def fetch(self, url: str, headers: dict[str, str] | None = None) -> HttpResponse:
+                del headers
+                raise SourceError(f"request failed for {url}: HTTP Error 403: Forbidden")
+
+        result = fetch_candidate_full_text(candidate, _FailingClient())
+
+        self.assertEqual(result.access_status, "paywalled")
+        self.assertEqual(result.access_url, "https://example.com/paywalled")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- treat access-blocked fetch failures such as `403` as likely paywalled retrieval cases instead of dropping them as generic unreadable failures
- include strong `unreadable` papers in `Requested Articles From User` so the report still asks the user for institution-only sources
- clean Google Scholar `[HTML]` title prefixes and harden Scholar metadata parsing for author and venue extraction

## Testing
- `python3 -m unittest discover -s tests`
- smoke run via subagent on `graph neural networks for molecular property prediction`

## Smoke Test Outcome
- run succeeded and generated `runs/20260429-085358-graph-neural-networks-for-molecular-property-prediction`
- the report now populated `Requested Articles From User` with blocked/unreadable papers
- remaining known issue: Semantic Scholar still frequently returns `HTTP 429`, which degrades source coverage