### PR TITLE
fix: respect context intent and rate limits

### DIFF
--- a/src/research_lab/engine.py
+++ b/src/research_lab/engine.py
@@ -34,11 +34,12 @@ def execute_run(
     seen_query_strings: set[str] = set()
     pool: list[PaperCandidate] = []
     warnings: list[str] = []
+    source_state = {"semanticscholar_enabled": True}
 
     seed_queries = build_seed_queries(brief)
     for query in seed_queries:
         _add_query(query, all_queries, seen_query_strings)
-        pool.extend(_search_all_sources(query, brief, client, warnings))
+        pool.extend(_search_all_sources(query, brief, client, warnings, source_state))
 
     ranked = rank_candidates(dedupe_candidates(pool), brief)
 
@@ -52,14 +53,14 @@ def execute_run(
         for query in expansion_queries:
             if not _add_query(query, all_queries, seen_query_strings):
                 continue
-            expanded_pool.extend(_search_all_sources(query, brief, client, warnings))
+            expanded_pool.extend(_search_all_sources(query, brief, client, warnings, source_state))
 
         for candidate in seed_candidates[:2]:
-            if candidate.source_id and candidate.source.startswith("semanticscholar"):
+            if source_state["semanticscholar_enabled"] and candidate.source_id and candidate.source.startswith("semanticscholar"):
                 try:
                     references = fetch_semantic_scholar_references(candidate.source_id, brief.per_query, client)
                 except SourceError as exc:
-                    warnings.append(str(exc))
+                    _handle_semantic_scholar_error(exc, warnings, source_state)
                     references = []
                 for reference in references:
                     reference.matched_queries.append(f"references:{candidate.title}")
@@ -95,6 +96,7 @@ def _search_all_sources(
     brief: ResearchBrief,
     client: HttpClient,
     warnings: list[str],
+    source_state: dict[str, bool],
 ) -> list[PaperCandidate]:
     collected: list[PaperCandidate] = []
     try:
@@ -111,13 +113,14 @@ def _search_all_sources(
         collected.extend(openalex_results)
     except SourceError as exc:
         warnings.append(str(exc))
-    try:
-        semantic_results = search_semantic_scholar(query.query, brief.per_query, brief.since_year, client)
-        for candidate in semantic_results:
-            candidate.matched_queries.append(query.query)
-        collected.extend(semantic_results)
-    except SourceError as exc:
-        warnings.append(str(exc))
+    if source_state["semanticscholar_enabled"]:
+        try:
+            semantic_results = search_semantic_scholar(query.query, brief.per_query, brief.since_year, client)
+            for candidate in semantic_results:
+                candidate.matched_queries.append(query.query)
+            collected.extend(semantic_results)
+        except SourceError as exc:
+            _handle_semantic_scholar_error(exc, warnings, source_state)
     try:
         web_results = search_duckduckgo(query.query, brief.web_per_query, client)
         for candidate in web_results:
@@ -133,6 +136,15 @@ def _search_all_sources(
     except SourceError as exc:
         warnings.append(str(exc))
     return collected
+
+
+def _handle_semantic_scholar_error(exc: SourceError, warnings: list[str], source_state: dict[str, bool]) -> None:
+    if "HTTP Error 429" in str(exc):
+        if source_state["semanticscholar_enabled"]:
+            warnings.append("semantic scholar disabled after rate limit")
+        source_state["semanticscholar_enabled"] = False
+        return
+    warnings.append(str(exc))
 
 
 def _add_query(query: QueryRecord, all_queries: list[QueryRecord], seen: set[str]) -> bool:

--- a/src/research_lab/rank.py
+++ b/src/research_lab/rank.py
@@ -11,6 +11,8 @@ VISUAL_TERMS = {"vision", "visual", "image", "images", "video", "clip"}
 ROBOTICS_TERMS = {"robot", "robotic", "robotics", "manipulation", "embodied"}
 BIOMED_TERMS = {"protein", "molecular", "biomedical", "medical", "drug", "clinical"}
 TEXT_TERMS = {"language", "languages", "llm", "llms", "text", "nlp"}
+SURVEY_TERMS = {"survey", "review", "overview"}
+BENCHMARK_TERMS = {"benchmark", "benchmarking", "comparison", "comparative", "evaluation"}
 
 
 def normalize_title(title: str) -> str:
@@ -138,6 +140,27 @@ def _domain_mismatch_penalty(topic_terms: set[str], text_terms: set[str]) -> tup
         penalty += 0.05
         reasons.append("biomed modality drift")
     return penalty, reasons
+
+
+def _context_intent_bonus(candidate: PaperCandidate, brief: ResearchBrief, searchable_lower: str) -> tuple[float, list[str]]:
+    context = brief.context.lower()
+    title_norm = normalize_title(candidate.title)
+    bonus = 0.0
+    reasons: list[str] = []
+
+    if any(term in context for term in SURVEY_TERMS) and any(term in title_norm for term in SURVEY_TERMS):
+        bonus += 0.14
+        reasons.append("matches survey intent")
+
+    if any(term in context for term in BENCHMARK_TERMS) and any(term in searchable_lower for term in BENCHMARK_TERMS):
+        bonus += 0.1
+        reasons.append("matches benchmark intent")
+
+    if "foundational" in context and candidate.citation_count >= 100:
+        bonus += 0.08
+        reasons.append("matches foundational intent")
+
+    return bonus, reasons
 
 
 def extract_evidence_sentences(text: str, brief: ResearchBrief, limit: int = 3) -> list[str]:
@@ -315,6 +338,10 @@ def score_candidate(candidate: PaperCandidate, brief: ResearchBrief) -> float:
     mismatch_penalty, mismatch_reasons = _domain_mismatch_penalty(topic_terms, text_terms)
     score -= mismatch_penalty
     reasons.extend(mismatch_reasons)
+
+    intent_bonus, intent_reasons = _context_intent_bonus(candidate, brief, searchable_lower)
+    score += intent_bonus
+    reasons.extend(intent_reasons)
 
     candidate.score = round(score, 4)
     candidate.reasons = reasons

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 import sys
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from research_lab.engine import _expansion_seed_candidates
-from research_lab.models import PaperCandidate, ResearchBrief
+from research_lab.engine import _expansion_seed_candidates, _search_all_sources
+from research_lab.models import PaperCandidate, QueryRecord, ResearchBrief
+from research_lab.sources import SourceError
 
 
 class EngineTests(unittest.TestCase):
@@ -60,6 +62,27 @@ class EngineTests(unittest.TestCase):
         seeds = _expansion_seed_candidates([web, drift_paper, weak_paper, clean_paper], brief)
 
         self.assertEqual([candidate.title for candidate in seeds], [clean_paper.title])
+
+    def test_search_all_sources_disables_semantic_scholar_after_rate_limit(self) -> None:
+        brief = ResearchBrief(topic="graph neural networks", context="")
+        query = QueryRecord(query="graph neural networks", origin="topic", iteration=0)
+        warnings: list[str] = []
+        source_state = {"semanticscholar_enabled": True}
+
+        with patch("research_lab.engine.search_arxiv", return_value=[]), patch(
+            "research_lab.engine.search_openalex", return_value=[]
+        ), patch("research_lab.engine.search_duckduckgo", return_value=[]), patch(
+            "research_lab.engine.search_google_scholar", return_value=[]
+        ), patch(
+            "research_lab.engine.search_semantic_scholar",
+            side_effect=SourceError("request failed for semantic scholar: HTTP Error 429:"),
+        ) as semantic_mock:
+            _search_all_sources(query, brief, object(), warnings, source_state)
+            _search_all_sources(query, brief, object(), warnings, source_state)
+
+        self.assertEqual(semantic_mock.call_count, 1)
+        self.assertFalse(source_state["semanticscholar_enabled"])
+        self.assertEqual(warnings, ["semantic scholar disabled after rate limit"])
 
 
 if __name__ == "__main__":

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -203,6 +203,38 @@ class RankTests(unittest.TestCase):
 
         self.assertEqual(ranked[0].title, precise.title)
 
+    def test_rank_prefers_review_when_context_requests_foundational_survey_sources(self) -> None:
+        brief = ResearchBrief(
+            topic="graph neural networks for molecular property prediction",
+            context="I want foundational and practical papers, plus strong surveys and benchmark-oriented sources.",
+        )
+        method_paper = PaperCandidate(
+            title="Cross-dependent graph neural networks for molecular property prediction",
+            abstract="A direct method paper for the task.",
+            url="https://example.com/method",
+            source="openalex",
+            source_id="oa:method",
+            year=2024,
+            citation_count=8,
+            document_kind="paper",
+            source_names=["openalex"],
+        )
+        review_paper = PaperCandidate(
+            title="A compact review of molecular property prediction with graph neural networks",
+            abstract="This review benchmarks models and surveys the field.",
+            url="https://example.com/review",
+            source="openalex",
+            source_id="oa:review",
+            year=2020,
+            citation_count=400,
+            document_kind="paper",
+            source_names=["openalex"],
+        )
+
+        ranked = rank_candidates([method_paper, review_paper], brief)
+
+        self.assertEqual(ranked[0].title, review_paper.title)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- disable Semantic Scholar for the rest of a run after the first `HTTP 429` so reports stop filling with repeated per-query rate-limit warnings
- add a small context-intent ranking bonus for survey/review, benchmark/comparison, and foundational requests
- cover both behaviors with focused engine and ranking tests

## Testing
- `python3 -m unittest discover -s tests`
- smoke run via subagent on `graph neural networks for molecular property prediction`

## Smoke Test Outcome
- run succeeded and generated `runs/20260429-090343-graph-neural-networks-for-molecular-property-prediction`
- `report.md` now shows a single warning: `semantic scholar disabled after rate limit`
- survey/foundational results moved up, including `A compact review of molecular property prediction with graph neural networks` at `#3`