### PR TITLE
fix: throttle fragile sources and surface web results

### DIFF
--- a/src/research_lab/engine.py
+++ b/src/research_lab/engine.py
@@ -37,9 +37,13 @@ def execute_run(
     pool: list[PaperCandidate] = []
     warnings: list[str] = []
     source_state = {
+        "arxiv_enabled": True,
+        "arxiv_requests_remaining": 6,
         "semanticscholar_enabled": bool(semantic_scholar_api_key),
         "semanticscholar_has_api_key": bool(semantic_scholar_api_key),
         "semanticscholar_requests_remaining": 999 if semantic_scholar_api_key else 0,
+        "googlescholar_enabled": brief.scholar_per_query > 0,
+        "googlescholar_requests_remaining": 3 if brief.scholar_per_query > 0 else 0,
     }
 
     seed_queries = build_seed_queries(brief)
@@ -106,13 +110,15 @@ def _search_all_sources(
     source_state: dict[str, object],
 ) -> list[PaperCandidate]:
     collected: list[PaperCandidate] = []
-    try:
-        arxiv_results = search_arxiv(query.query, brief.per_query, brief.since_year, client)
-        for candidate in arxiv_results:
-            candidate.matched_queries.append(query.query)
-        collected.extend(arxiv_results)
-    except SourceError as exc:
-        warnings.append(str(exc))
+    if _should_use_arxiv(query, source_state):
+        try:
+            source_state["arxiv_requests_remaining"] -= 1
+            arxiv_results = search_arxiv(query.query, brief.per_query, brief.since_year, client)
+            for candidate in arxiv_results:
+                candidate.matched_queries.append(query.query)
+            collected.extend(arxiv_results)
+        except SourceError as exc:
+            _handle_arxiv_error(exc, warnings, source_state)
     try:
         openalex_results = search_openalex(query.query, brief.per_query, brief.since_year, client)
         for candidate in openalex_results:
@@ -136,14 +142,26 @@ def _search_all_sources(
         collected.extend(web_results)
     except SourceError as exc:
         warnings.append(str(exc))
-    try:
-        scholar_results = search_google_scholar(query.query, brief.scholar_per_query, client)
-        for candidate in scholar_results:
-            candidate.matched_queries.append(query.query)
-        collected.extend(scholar_results)
-    except SourceError as exc:
-        warnings.append(str(exc))
+    if _should_use_google_scholar(query, source_state):
+        try:
+            source_state["googlescholar_requests_remaining"] -= 1
+            scholar_results = search_google_scholar(query.query, brief.scholar_per_query, client)
+            for candidate in scholar_results:
+                candidate.matched_queries.append(query.query)
+            collected.extend(scholar_results)
+        except SourceError as exc:
+            _handle_google_scholar_error(exc, warnings, source_state)
     return collected
+
+
+def _handle_arxiv_error(exc: SourceError, warnings: list[str], source_state: dict[str, object]) -> None:
+    message = str(exc)
+    if "HTTP Error 429" in message or "timed out" in message:
+        if source_state["arxiv_enabled"]:
+            warnings.append("arxiv disabled after rate limit")
+        source_state["arxiv_enabled"] = False
+        return
+    warnings.append(message)
 
 
 def _handle_semantic_scholar_error(exc: SourceError, warnings: list[str], source_state: dict[str, object]) -> None:
@@ -155,6 +173,23 @@ def _handle_semantic_scholar_error(exc: SourceError, warnings: list[str], source
     warnings.append(str(exc))
 
 
+def _handle_google_scholar_error(exc: SourceError, warnings: list[str], source_state: dict[str, object]) -> None:
+    if "google scholar blocked automated access" in str(exc):
+        if source_state["googlescholar_enabled"]:
+            warnings.append("google scholar disabled after block")
+        source_state["googlescholar_enabled"] = False
+        return
+    warnings.append(str(exc))
+
+
+def _should_use_arxiv(query: QueryRecord, source_state: dict[str, object]) -> bool:
+    if not source_state["arxiv_enabled"]:
+        return False
+    if int(source_state["arxiv_requests_remaining"]) <= 0:
+        return False
+    return query.origin not in {"author_expansion", "title_expansion"}
+
+
 def _should_use_semantic_scholar(query: QueryRecord | None, source_state: dict[str, object]) -> bool:
     if not source_state["semanticscholar_enabled"]:
         return False
@@ -164,6 +199,14 @@ def _should_use_semantic_scholar(query: QueryRecord | None, source_state: dict[s
         return True
     if query is None:
         return True
+    return query.origin not in {"author_expansion", "title_expansion"}
+
+
+def _should_use_google_scholar(query: QueryRecord, source_state: dict[str, object]) -> bool:
+    if not source_state["googlescholar_enabled"]:
+        return False
+    if int(source_state["googlescholar_requests_remaining"]) <= 0:
+        return False
     return query.origin not in {"author_expansion", "title_expansion"}
 
 

--- a/src/research_lab/report.py
+++ b/src/research_lab/report.py
@@ -52,6 +52,7 @@ def write_run_files(run_dir: Path, artifacts: RunArtifacts) -> None:
     exploratory = [candidate for candidate in top if candidate.score < 0.35]
     requested_articles = [candidate for candidate in top if _needs_user_article(candidate)]
     broad_intent_matches = [candidate for candidate in top if _matches_broad_intent(candidate)]
+    useful_web_sources = [candidate for candidate in artifacts.candidates if candidate.document_kind == "web"]
 
     lines: list[str] = [
         f"# Research Run {artifacts.run_id}",
@@ -73,6 +74,10 @@ def write_run_files(run_dir: Path, artifacts: RunArtifacts) -> None:
     if broad_intent_matches:
         lines.extend(["", "## Broad Coverage Matches"])
         for candidate in broad_intent_matches[:4]:
+            lines.extend(_render_candidate(candidate))
+    if useful_web_sources:
+        lines.extend(["", "## Useful Web Sources"])
+        for candidate in useful_web_sources[:4]:
             lines.extend(_render_candidate(candidate))
     lines.extend(["", "## High Confidence Matches"])
     if high_confidence:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -68,9 +68,13 @@ class EngineTests(unittest.TestCase):
         query = QueryRecord(query="graph neural networks", origin="topic", iteration=0)
         warnings: list[str] = []
         source_state = {
+            "arxiv_enabled": True,
+            "arxiv_requests_remaining": 6,
             "semanticscholar_enabled": True,
             "semanticscholar_has_api_key": False,
             "semanticscholar_requests_remaining": 5,
+            "googlescholar_enabled": True,
+            "googlescholar_requests_remaining": 3,
         }
 
         with patch("research_lab.engine.search_arxiv", return_value=[]), patch(
@@ -93,9 +97,13 @@ class EngineTests(unittest.TestCase):
         query = QueryRecord(query='"Jane Doe" graph neural networks', origin="author_expansion", iteration=1)
         warnings: list[str] = []
         source_state = {
+            "arxiv_enabled": True,
+            "arxiv_requests_remaining": 6,
             "semanticscholar_enabled": True,
             "semanticscholar_has_api_key": False,
             "semanticscholar_requests_remaining": 5,
+            "googlescholar_enabled": True,
+            "googlescholar_requests_remaining": 3,
         }
 
         with patch("research_lab.engine.search_arxiv", return_value=[]), patch(
@@ -107,6 +115,57 @@ class EngineTests(unittest.TestCase):
 
         semantic_mock.assert_not_called()
         self.assertEqual(source_state["semanticscholar_requests_remaining"], 5)
+
+    def test_search_all_sources_disables_arxiv_after_rate_limit(self) -> None:
+        brief = ResearchBrief(topic="graph neural networks", context="")
+        query = QueryRecord(query="graph neural networks", origin="topic", iteration=0)
+        warnings: list[str] = []
+        source_state = {
+            "arxiv_enabled": True,
+            "arxiv_requests_remaining": 6,
+            "semanticscholar_enabled": False,
+            "semanticscholar_has_api_key": False,
+            "semanticscholar_requests_remaining": 0,
+            "googlescholar_enabled": False,
+            "googlescholar_requests_remaining": 0,
+        }
+
+        with patch("research_lab.engine.search_arxiv", side_effect=SourceError("request failed for arxiv: HTTP Error 429:")) as arxiv_mock, patch(
+            "research_lab.engine.search_openalex", return_value=[]
+        ), patch("research_lab.engine.search_duckduckgo", return_value=[]):
+            _search_all_sources(query, brief, object(), warnings, source_state)
+            _search_all_sources(query, brief, object(), warnings, source_state)
+
+        self.assertEqual(arxiv_mock.call_count, 1)
+        self.assertFalse(source_state["arxiv_enabled"])
+        self.assertEqual(warnings, ["arxiv disabled after rate limit"])
+
+    def test_search_all_sources_disables_google_scholar_after_block(self) -> None:
+        brief = ResearchBrief(topic="graph neural networks", context="")
+        query = QueryRecord(query="graph neural networks", origin="topic", iteration=0)
+        warnings: list[str] = []
+        source_state = {
+            "arxiv_enabled": False,
+            "arxiv_requests_remaining": 0,
+            "semanticscholar_enabled": False,
+            "semanticscholar_has_api_key": False,
+            "semanticscholar_requests_remaining": 0,
+            "googlescholar_enabled": True,
+            "googlescholar_requests_remaining": 3,
+        }
+
+        with patch("research_lab.engine.search_openalex", return_value=[]), patch(
+            "research_lab.engine.search_duckduckgo", return_value=[]
+        ), patch(
+            "research_lab.engine.search_google_scholar",
+            side_effect=SourceError("google scholar blocked automated access"),
+        ) as scholar_mock:
+            _search_all_sources(query, brief, object(), warnings, source_state)
+            _search_all_sources(query, brief, object(), warnings, source_state)
+
+        self.assertEqual(scholar_mock.call_count, 1)
+        self.assertFalse(source_state["googlescholar_enabled"])
+        self.assertEqual(warnings, ["google scholar disabled after block"])
 
 
 if __name__ == "__main__":

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -88,6 +88,30 @@ class ReportTests(unittest.TestCase):
             self.assertIn("## Broad Coverage Matches", report)
             self.assertIn("A compact review of graph neural networks", report)
 
+    def test_write_run_files_includes_useful_web_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_dir = Path(tmpdir)
+            brief = ResearchBrief(topic="ai agents", context="include useful engineering explainers")
+            candidate = PaperCandidate(
+                title="Agentic Engineering Explained",
+                abstract="A practical engineering explainer.",
+                url="https://example.com/blog",
+                source="duckduckgo",
+                source_id="web:blog",
+                venue="example.com",
+                document_kind="web",
+                source_names=["duckduckgo"],
+                score=0.44,
+                reasons=["topic overlap 2/3", "context overlap 1/4"],
+            )
+            artifacts = RunArtifacts.create("run-4", str(run_dir), brief, [], [candidate], "program")
+
+            write_run_files(run_dir, artifacts)
+
+            report = (run_dir / "report.md").read_text(encoding="utf-8")
+            self.assertIn("## Useful Web Sources", report)
+            self.assertIn("Agentic Engineering Explained", report)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- throttle arXiv and Google Scholar usage across a run by skipping low-value expansion queries and disabling each source after the first rate-limit/block event
- collapse fragile-source failures into a single warning line instead of repeated per-query noise
- add a `Useful Web Sources` section so non-academic web results are visible even when papers still outrank them

## Testing
- `python3 -m unittest discover -s tests`
- subagent smoke run on `AI coding agents for software engineering productivity`

## Smoke Test Outcome
- run succeeded and generated `runs/20260429-122402-ai-coding-agents-for-software-engineering-productivity`
- `Useful Web Sources` is present in the report
- best surfaced web result: `Agentic Engineering: How Swarms of AI Agents Are Redefining Software Engineering`
- fragile academic sources now degrade to single warnings: `arxiv disabled after rate limit` and `google scholar disabled after block`