### PR TITLE
refactor: deepen retrieval policy module

### DIFF
--- a/src/research_lab/engine.py
+++ b/src/research_lab/engine.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections import Counter
-import os
 from pathlib import Path
 
 from research_lab.identity import candidates_match
@@ -10,17 +9,8 @@ from research_lab.models import EnrichedCandidate, PaperCandidate, QueryRecord, 
 from research_lab.planner import build_expansion_queries, build_seed_queries
 from research_lab.rank import dedupe_candidates, extract_evidence_sentences, rank_candidates
 from research_lab.report import write_run_files
-from research_lab.sources import (
-    HttpClient,
-    SourceError,
-    fetch_candidate_full_text,
-    fetch_semantic_scholar_references,
-    search_arxiv,
-    search_duckduckgo,
-    search_google_scholar,
-    search_openalex,
-    search_semantic_scholar,
-)
+from research_lab.retrieval import RetrievalPolicy
+from research_lab.sources import HttpClient, SourceError, fetch_candidate_full_text
 from research_lab.store import init_db, record_run
 
 
@@ -32,25 +22,16 @@ def execute_run(
     db_path: Path,
 ) -> RunArtifacts:
     client = HttpClient()
-    semantic_scholar_api_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY", "").strip()
+    retrieval = RetrievalPolicy(client=client, scholar_per_query=brief.scholar_per_query)
     all_queries: list[QueryRecord] = []
     seen_query_strings: set[str] = set()
     pool: list[PaperCandidate | RetrievalCandidate] = []
-    warnings: list[str] = []
-    source_state = {
-        "arxiv_enabled": True,
-        "arxiv_requests_remaining": 6,
-        "semanticscholar_enabled": bool(semantic_scholar_api_key),
-        "semanticscholar_has_api_key": bool(semantic_scholar_api_key),
-        "semanticscholar_requests_remaining": 999 if semantic_scholar_api_key else 0,
-        "googlescholar_enabled": brief.scholar_per_query > 0,
-        "googlescholar_requests_remaining": 3 if brief.scholar_per_query > 0 else 0,
-    }
+    warnings: list[str] = retrieval.warnings
 
     seed_queries = build_seed_queries(brief)
     for query in seed_queries:
         _add_query(query, all_queries, seen_query_strings)
-        pool.extend(_search_all_sources(query, brief, client, warnings, source_state))
+        pool.extend(retrieval.search(query, brief))
 
     ranked = rank_candidates(dedupe_candidates(pool), brief)
 
@@ -64,19 +45,10 @@ def execute_run(
         for query in expansion_queries:
             if not _add_query(query, all_queries, seen_query_strings):
                 continue
-            expanded_pool.extend(_search_all_sources(query, brief, client, warnings, source_state))
+            expanded_pool.extend(retrieval.search(query, brief))
 
         for candidate in seed_candidates[:2]:
-            if _should_use_semantic_scholar(None, source_state) and candidate.source_id and candidate.source.startswith("semanticscholar"):
-                try:
-                    source_state["semanticscholar_requests_remaining"] -= 1
-                    references = fetch_semantic_scholar_references(candidate.source_id, brief.per_query, client)
-                except SourceError as exc:
-                    _handle_semantic_scholar_error(exc, warnings, source_state)
-                    references = []
-                for reference in references:
-                    reference.matched_queries.append(f"references:{candidate.title}")
-                    expanded_pool.append(reference)
+            expanded_pool.extend(retrieval.fetch_references(candidate, brief.per_query))
 
         if not expanded_pool:
             continue
@@ -104,114 +76,6 @@ def execute_run(
     init_db(db_path)
     record_run(db_path, artifacts)
     return artifacts
-
-
-def _search_all_sources(
-    query: QueryRecord,
-    brief: ResearchBrief,
-    client: HttpClient,
-    warnings: list[str],
-    source_state: dict[str, object],
-) -> list[RetrievalCandidate]:
-    collected: list[RetrievalCandidate] = []
-    if _should_use_arxiv(query, source_state):
-        try:
-            source_state["arxiv_requests_remaining"] -= 1
-            arxiv_results = search_arxiv(query.query, brief.per_query, brief.since_year, client)
-            for candidate in arxiv_results:
-                candidate.matched_queries.append(query.query)
-            collected.extend(arxiv_results)
-        except SourceError as exc:
-            _handle_arxiv_error(exc, warnings, source_state)
-    try:
-        openalex_results = search_openalex(query.query, brief.per_query, brief.since_year, client)
-        for candidate in openalex_results:
-            candidate.matched_queries.append(query.query)
-        collected.extend(openalex_results)
-    except SourceError as exc:
-        warnings.append(str(exc))
-    if _should_use_semantic_scholar(query, source_state):
-        try:
-            source_state["semanticscholar_requests_remaining"] -= 1
-            semantic_results = search_semantic_scholar(query.query, brief.per_query, brief.since_year, client)
-            for candidate in semantic_results:
-                candidate.matched_queries.append(query.query)
-            collected.extend(semantic_results)
-        except SourceError as exc:
-            _handle_semantic_scholar_error(exc, warnings, source_state)
-    try:
-        web_results = search_duckduckgo(query.query, brief.web_per_query, client)
-        for candidate in web_results:
-            candidate.matched_queries.append(query.query)
-        collected.extend(web_results)
-    except SourceError as exc:
-        warnings.append(str(exc))
-    if _should_use_google_scholar(query, source_state):
-        try:
-            source_state["googlescholar_requests_remaining"] -= 1
-            scholar_results = search_google_scholar(query.query, brief.scholar_per_query, client)
-            for candidate in scholar_results:
-                candidate.matched_queries.append(query.query)
-            collected.extend(scholar_results)
-        except SourceError as exc:
-            _handle_google_scholar_error(exc, warnings, source_state)
-    return collected
-
-
-def _handle_arxiv_error(exc: SourceError, warnings: list[str], source_state: dict[str, object]) -> None:
-    message = str(exc)
-    if "HTTP Error 429" in message or "timed out" in message:
-        if source_state["arxiv_enabled"]:
-            warnings.append("arxiv disabled after rate limit")
-        source_state["arxiv_enabled"] = False
-        return
-    warnings.append(message)
-
-
-def _handle_semantic_scholar_error(exc: SourceError, warnings: list[str], source_state: dict[str, object]) -> None:
-    if "HTTP Error 429" in str(exc):
-        if source_state["semanticscholar_enabled"]:
-            warnings.append("semantic scholar disabled after rate limit")
-        source_state["semanticscholar_enabled"] = False
-        return
-    warnings.append(str(exc))
-
-
-def _handle_google_scholar_error(exc: SourceError, warnings: list[str], source_state: dict[str, object]) -> None:
-    if "google scholar blocked automated access" in str(exc):
-        if source_state["googlescholar_enabled"]:
-            warnings.append("google scholar disabled after block")
-        source_state["googlescholar_enabled"] = False
-        return
-    warnings.append(str(exc))
-
-
-def _should_use_arxiv(query: QueryRecord, source_state: dict[str, object]) -> bool:
-    if not source_state["arxiv_enabled"]:
-        return False
-    if int(source_state["arxiv_requests_remaining"]) <= 0:
-        return False
-    return query.origin not in {"author_expansion", "title_expansion"}
-
-
-def _should_use_semantic_scholar(query: QueryRecord | None, source_state: dict[str, object]) -> bool:
-    if not source_state["semanticscholar_enabled"]:
-        return False
-    if int(source_state["semanticscholar_requests_remaining"]) <= 0:
-        return False
-    if bool(source_state["semanticscholar_has_api_key"]):
-        return True
-    if query is None:
-        return True
-    return query.origin not in {"author_expansion", "title_expansion"}
-
-
-def _should_use_google_scholar(query: QueryRecord, source_state: dict[str, object]) -> bool:
-    if not source_state["googlescholar_enabled"]:
-        return False
-    if int(source_state["googlescholar_requests_remaining"]) <= 0:
-        return False
-    return query.origin not in {"author_expansion", "title_expansion"}
 
 
 def _add_query(query: QueryRecord, all_queries: list[QueryRecord], seen: set[str]) -> bool:

--- a/src/research_lab/retrieval.py
+++ b/src/research_lab/retrieval.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+
+from research_lab.models import QueryRecord, ResearchBrief, RetrievalCandidate, ScoredCandidate
+from research_lab.sources import (
+    HttpClient,
+    SourceError,
+    fetch_semantic_scholar_references,
+    search_arxiv,
+    search_duckduckgo,
+    search_google_scholar,
+    search_openalex,
+    search_semantic_scholar,
+)
+
+
+class RetrievalPolicy:
+    def __init__(self, client: HttpClient | None = None, scholar_per_query: int = 0) -> None:
+        semantic_scholar_api_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY", "").strip()
+        self.client = client or HttpClient()
+        self.warnings: list[str] = []
+        self._state: dict[str, object] = {
+            "arxiv_enabled": True,
+            "arxiv_requests_remaining": 6,
+            "semanticscholar_enabled": bool(semantic_scholar_api_key),
+            "semanticscholar_has_api_key": bool(semantic_scholar_api_key),
+            "semanticscholar_requests_remaining": 999 if semantic_scholar_api_key else 0,
+            "googlescholar_enabled": scholar_per_query > 0,
+            "googlescholar_requests_remaining": 3 if scholar_per_query > 0 else 0,
+        }
+
+    def search(self, query: QueryRecord, brief: ResearchBrief) -> list[RetrievalCandidate]:
+        collected: list[RetrievalCandidate] = []
+        if self._should_use_arxiv(query):
+            try:
+                self._state["arxiv_requests_remaining"] = int(self._state["arxiv_requests_remaining"]) - 1
+                collected.extend(self._annotate(query, search_arxiv(query.query, brief.per_query, brief.since_year, self.client)))
+            except SourceError as exc:
+                self._handle_arxiv_error(exc)
+        try:
+            collected.extend(self._annotate(query, search_openalex(query.query, brief.per_query, brief.since_year, self.client)))
+        except SourceError as exc:
+            self.warnings.append(str(exc))
+        if self._should_use_semantic_scholar(query):
+            try:
+                self._state["semanticscholar_requests_remaining"] = int(self._state["semanticscholar_requests_remaining"]) - 1
+                collected.extend(self._annotate(query, search_semantic_scholar(query.query, brief.per_query, brief.since_year, self.client)))
+            except SourceError as exc:
+                self._handle_semantic_scholar_error(exc)
+        try:
+            collected.extend(self._annotate(query, search_duckduckgo(query.query, brief.web_per_query, self.client)))
+        except SourceError as exc:
+            self.warnings.append(str(exc))
+        if self._should_use_google_scholar(query):
+            try:
+                self._state["googlescholar_requests_remaining"] = int(self._state["googlescholar_requests_remaining"]) - 1
+                collected.extend(self._annotate(query, search_google_scholar(query.query, brief.scholar_per_query, self.client)))
+            except SourceError as exc:
+                self._handle_google_scholar_error(exc)
+        return collected
+
+    def fetch_references(self, candidate: ScoredCandidate, per_query: int) -> list[RetrievalCandidate]:
+        if not self._should_use_semantic_scholar(None):
+            return []
+        if not candidate.source_id or not candidate.source.startswith("semanticscholar"):
+            return []
+        try:
+            self._state["semanticscholar_requests_remaining"] = int(self._state["semanticscholar_requests_remaining"]) - 1
+            references = fetch_semantic_scholar_references(candidate.source_id, per_query, self.client)
+        except SourceError as exc:
+            self._handle_semantic_scholar_error(exc)
+            return []
+        for reference in references:
+            reference.matched_queries.append(f"references:{candidate.title}")
+        return references
+
+    def _annotate(self, query: QueryRecord, candidates: list[RetrievalCandidate]) -> list[RetrievalCandidate]:
+        for candidate in candidates:
+            candidate.matched_queries.append(query.query)
+        return candidates
+
+    def _handle_arxiv_error(self, exc: SourceError) -> None:
+        message = str(exc)
+        if "HTTP Error 429" in message or "timed out" in message:
+            if self._state["arxiv_enabled"]:
+                self.warnings.append("arxiv disabled after rate limit")
+            self._state["arxiv_enabled"] = False
+            return
+        self.warnings.append(message)
+
+    def _handle_semantic_scholar_error(self, exc: SourceError) -> None:
+        if "HTTP Error 429" in str(exc):
+            if self._state["semanticscholar_enabled"]:
+                self.warnings.append("semantic scholar disabled after rate limit")
+            self._state["semanticscholar_enabled"] = False
+            return
+        self.warnings.append(str(exc))
+
+    def _handle_google_scholar_error(self, exc: SourceError) -> None:
+        if "google scholar blocked automated access" in str(exc):
+            if self._state["googlescholar_enabled"]:
+                self.warnings.append("google scholar disabled after block")
+            self._state["googlescholar_enabled"] = False
+            return
+        self.warnings.append(str(exc))
+
+    def _should_use_arxiv(self, query: QueryRecord) -> bool:
+        if not self._state["arxiv_enabled"]:
+            return False
+        if int(self._state["arxiv_requests_remaining"]) <= 0:
+            return False
+        return query.origin not in {"author_expansion", "title_expansion"}
+
+    def _should_use_semantic_scholar(self, query: QueryRecord | None) -> bool:
+        if not self._state["semanticscholar_enabled"]:
+            return False
+        if int(self._state["semanticscholar_requests_remaining"]) <= 0:
+            return False
+        if bool(self._state["semanticscholar_has_api_key"]):
+            return True
+        if query is None:
+            return True
+        return query.origin not in {"author_expansion", "title_expansion"}
+
+    def _should_use_google_scholar(self, query: QueryRecord) -> bool:
+        if not self._state["googlescholar_enabled"]:
+            return False
+        if int(self._state["googlescholar_requests_remaining"]) <= 0:
+            return False
+        return query.origin not in {"author_expansion", "title_expansion"}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,13 +1,33 @@
 from pathlib import Path
 import sys
 import unittest
-from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from research_lab.engine import _expansion_seed_candidates, _search_all_sources
+from research_lab.engine import _expansion_seed_candidates
 from research_lab.models import PaperCandidate, QueryRecord, ResearchBrief
-from research_lab.sources import SourceError
+from research_lab.retrieval import RetrievalPolicy
+from research_lab.sources import HttpClient, HttpResponse, SourceError
+
+
+class _FakeClient(HttpClient):
+    def __init__(self, responses: dict[str, object]) -> None:
+        super().__init__()
+        self.responses = responses
+
+    def fetch(self, url: str, headers: dict[str, str] | None = None) -> HttpResponse:
+        del headers
+        response = self.responses[url]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def get_json(self, url: str, headers: dict[str, str] | None = None) -> dict:
+        del headers
+        response = self.responses[url]
+        if isinstance(response, Exception):
+            raise response
+        return response
 
 
 class EngineTests(unittest.TestCase):
@@ -85,109 +105,82 @@ class EngineTests(unittest.TestCase):
 
         self.assertEqual([item.title for item in seeds], [candidate.title])
 
-    def test_search_all_sources_disables_semantic_scholar_after_rate_limit(self) -> None:
+    def test_retrieval_policy_disables_semantic_scholar_after_rate_limit(self) -> None:
         brief = ResearchBrief(topic="graph neural networks", context="")
         query = QueryRecord(query="graph neural networks", origin="topic", iteration=0)
-        warnings: list[str] = []
-        source_state = {
-            "arxiv_enabled": True,
-            "arxiv_requests_remaining": 6,
-            "semanticscholar_enabled": True,
-            "semanticscholar_has_api_key": False,
-            "semanticscholar_requests_remaining": 5,
-            "googlescholar_enabled": True,
-            "googlescholar_requests_remaining": 3,
-        }
+        client = _FakeClient(
+            {
+                "https://api.openalex.org/works?search=graph+neural+networks&per-page=8&sort=relevance_score%3Adesc": {"results": []},
+                "https://api.semanticscholar.org/graph/v1/paper/search?query=graph+neural+networks&limit=8&fields=paperId%2Ctitle%2Cabstract%2Curl%2Cyear%2Cauthors%2Cvenue%2CcitationCount%2CexternalIds%2CopenAccessPdf%2CfieldsOfStudy": SourceError("request failed for semantic scholar: HTTP Error 429:"),
+                "https://html.duckduckgo.com/html/?q=graph+neural+networks": HttpResponse(body=b"<html></html>", content_type="text/html", final_url="https://html.duckduckgo.com/html/?q=graph+neural+networks"),
+            }
+        )
+        policy = RetrievalPolicy(client=client, scholar_per_query=0)
+        policy._state["arxiv_enabled"] = False
+        policy._state["semanticscholar_enabled"] = True
+        policy._state["semanticscholar_requests_remaining"] = 5
 
-        with patch("research_lab.engine.search_arxiv", return_value=[]), patch(
-            "research_lab.engine.search_openalex", return_value=[]
-        ), patch("research_lab.engine.search_duckduckgo", return_value=[]), patch(
-            "research_lab.engine.search_google_scholar", return_value=[]
-        ), patch(
-            "research_lab.engine.search_semantic_scholar",
-            side_effect=SourceError("request failed for semantic scholar: HTTP Error 429:"),
-        ) as semantic_mock:
-            _search_all_sources(query, brief, object(), warnings, source_state)
-            _search_all_sources(query, brief, object(), warnings, source_state)
+        policy.search(query, brief)
+        policy.search(query, brief)
 
-        self.assertEqual(semantic_mock.call_count, 1)
-        self.assertFalse(source_state["semanticscholar_enabled"])
-        self.assertEqual(warnings, ["semantic scholar disabled after rate limit"])
+        self.assertEqual(policy.warnings, ["semantic scholar disabled after rate limit"])
+        self.assertFalse(policy._state["semanticscholar_enabled"])
 
-    def test_search_all_sources_skips_semantic_scholar_for_low_value_expansion_without_key(self) -> None:
+    def test_retrieval_policy_skips_semantic_scholar_for_low_value_expansion_without_key(self) -> None:
         brief = ResearchBrief(topic="graph neural networks", context="")
         query = QueryRecord(query='"Jane Doe" graph neural networks', origin="author_expansion", iteration=1)
-        warnings: list[str] = []
-        source_state = {
-            "arxiv_enabled": True,
-            "arxiv_requests_remaining": 6,
-            "semanticscholar_enabled": True,
-            "semanticscholar_has_api_key": False,
-            "semanticscholar_requests_remaining": 5,
-            "googlescholar_enabled": True,
-            "googlescholar_requests_remaining": 3,
-        }
+        client = _FakeClient(
+            {
+                "https://api.openalex.org/works?search=%22Jane+Doe%22+graph+neural+networks&per-page=8&sort=relevance_score%3Adesc": {"results": []},
+                "https://html.duckduckgo.com/html/?q=%22Jane+Doe%22+graph+neural+networks": HttpResponse(body=b"<html></html>", content_type="text/html", final_url="https://html.duckduckgo.com/html/?q=%22Jane+Doe%22+graph+neural+networks"),
+            }
+        )
+        policy = RetrievalPolicy(client=client, scholar_per_query=0)
+        policy._state["semanticscholar_enabled"] = True
+        policy._state["semanticscholar_requests_remaining"] = 5
 
-        with patch("research_lab.engine.search_arxiv", return_value=[]), patch(
-            "research_lab.engine.search_openalex", return_value=[]
-        ), patch("research_lab.engine.search_duckduckgo", return_value=[]), patch(
-            "research_lab.engine.search_google_scholar", return_value=[]
-        ), patch("research_lab.engine.search_semantic_scholar") as semantic_mock:
-            _search_all_sources(query, brief, object(), warnings, source_state)
+        policy.search(query, brief)
 
-        semantic_mock.assert_not_called()
-        self.assertEqual(source_state["semanticscholar_requests_remaining"], 5)
+        self.assertEqual(policy._state["semanticscholar_requests_remaining"], 5)
 
-    def test_search_all_sources_disables_arxiv_after_rate_limit(self) -> None:
+    def test_retrieval_policy_disables_arxiv_after_rate_limit(self) -> None:
         brief = ResearchBrief(topic="graph neural networks", context="")
         query = QueryRecord(query="graph neural networks", origin="topic", iteration=0)
-        warnings: list[str] = []
-        source_state = {
-            "arxiv_enabled": True,
-            "arxiv_requests_remaining": 6,
-            "semanticscholar_enabled": False,
-            "semanticscholar_has_api_key": False,
-            "semanticscholar_requests_remaining": 0,
-            "googlescholar_enabled": False,
-            "googlescholar_requests_remaining": 0,
-        }
+        client = _FakeClient(
+            {
+                "https://export.arxiv.org/api/query?search_query=all%3Agraph+neural+networks&start=0&max_results=8&sortBy=relevance&sortOrder=descending": SourceError("request failed for arxiv: HTTP Error 429:"),
+                "https://api.openalex.org/works?search=graph+neural+networks&per-page=8&sort=relevance_score%3Adesc": {"results": []},
+                "https://html.duckduckgo.com/html/?q=graph+neural+networks": HttpResponse(body=b"<html></html>", content_type="text/html", final_url="https://html.duckduckgo.com/html/?q=graph+neural+networks"),
+            }
+        )
+        policy = RetrievalPolicy(client=client, scholar_per_query=0)
 
-        with patch("research_lab.engine.search_arxiv", side_effect=SourceError("request failed for arxiv: HTTP Error 429:")) as arxiv_mock, patch(
-            "research_lab.engine.search_openalex", return_value=[]
-        ), patch("research_lab.engine.search_duckduckgo", return_value=[]):
-            _search_all_sources(query, brief, object(), warnings, source_state)
-            _search_all_sources(query, brief, object(), warnings, source_state)
+        policy.search(query, brief)
+        policy.search(query, brief)
 
-        self.assertEqual(arxiv_mock.call_count, 1)
-        self.assertFalse(source_state["arxiv_enabled"])
-        self.assertEqual(warnings, ["arxiv disabled after rate limit"])
+        self.assertEqual(policy.warnings, ["arxiv disabled after rate limit"])
+        self.assertFalse(policy._state["arxiv_enabled"])
 
-    def test_search_all_sources_disables_google_scholar_after_block(self) -> None:
-        brief = ResearchBrief(topic="graph neural networks", context="")
+    def test_retrieval_policy_disables_google_scholar_after_block(self) -> None:
+        brief = ResearchBrief(topic="graph neural networks", context="", scholar_per_query=1)
         query = QueryRecord(query="graph neural networks", origin="topic", iteration=0)
-        warnings: list[str] = []
-        source_state = {
-            "arxiv_enabled": False,
-            "arxiv_requests_remaining": 0,
-            "semanticscholar_enabled": False,
-            "semanticscholar_has_api_key": False,
-            "semanticscholar_requests_remaining": 0,
-            "googlescholar_enabled": True,
-            "googlescholar_requests_remaining": 3,
-        }
+        client = _FakeClient(
+            {
+                "https://api.openalex.org/works?search=graph+neural+networks&per-page=8&sort=relevance_score%3Adesc": {"results": []},
+                "https://html.duckduckgo.com/html/?q=graph+neural+networks": HttpResponse(body=b"<html></html>", content_type="text/html", final_url="https://html.duckduckgo.com/html/?q=graph+neural+networks"),
+                "https://scholar.google.com/scholar?hl=en&q=graph+neural+networks&num=1": SourceError("google scholar blocked automated access"),
+            }
+        )
+        policy = RetrievalPolicy(client=client, scholar_per_query=0)
+        policy._state["arxiv_enabled"] = False
+        policy._state["googlescholar_enabled"] = True
+        policy._state["googlescholar_requests_remaining"] = 3
 
-        with patch("research_lab.engine.search_openalex", return_value=[]), patch(
-            "research_lab.engine.search_duckduckgo", return_value=[]
-        ), patch(
-            "research_lab.engine.search_google_scholar",
-            side_effect=SourceError("google scholar blocked automated access"),
-        ) as scholar_mock:
-            _search_all_sources(query, brief, object(), warnings, source_state)
-            _search_all_sources(query, brief, object(), warnings, source_state)
+        policy.search(query, brief)
+        policy.search(query, brief)
 
-        self.assertEqual(scholar_mock.call_count, 1)
-        self.assertFalse(source_state["googlescholar_enabled"])
-        self.assertEqual(warnings, ["google scholar disabled after block"])
+        self.assertEqual(policy.warnings, ["google scholar disabled after block"])
+        self.assertFalse(policy._state["googlescholar_enabled"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- deepen retrieval behind a dedicated `RetrievalPolicy` module that owns source selection, throttling, warning normalization, and query annotation
- remove shallow source-gating and source-state control flow from `engine.py`
- add retrieval-policy tests that exercise the seam directly instead of patching many adapter calls through the engine

## Verification
- `python3 -m unittest discover -s tests`
- `PYTHONPATH=src python3 -m research_lab run --topic "AI coding agents for software engineering productivity" --context "I want strong academic papers, benchmarks, and useful industry blog posts or engineering explainers from labs and engineering teams." --iterations 1 --per-query 4 --web-per-query 4 --scholar-per-query 2 --full-text-top-n 6 --top-k 10`

Relates to #14