### PR TITLE
refactor: deepen document enrichment module

### DIFF
--- a/src/research_lab/engine.py
+++ b/src/research_lab/engine.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import Counter
 from pathlib import Path
 
-from research_lab.enrichment import enrich_candidate
+from research_lab.enrichment import enrich_candidates
 from research_lab.identity import candidates_match
 from research_lab.llm import LlmClient, LlmError, rerank_candidates_with_llm, summarize_candidates_with_llm
 from research_lab.models import EnrichedCandidate, PaperCandidate, QueryRecord, ResearchBrief, RetrievalCandidate, RunArtifacts, ScoredCandidate
@@ -56,7 +56,8 @@ def execute_run(
         pool.extend(expanded_pool)
         ranked = rank_candidates(dedupe_candidates(pool), brief)
 
-    enriched = _enrich_top_candidates(ranked[: brief.full_text_top_n], brief, client, warnings)
+    enriched, enrichment_warnings = enrich_candidates(ranked[: brief.full_text_top_n], brief, client)
+    warnings.extend(enrichment_warnings)
     pool.extend(candidate.to_paper_candidate() for candidate in enriched)
     deduped_pool = dedupe_candidates(pool)
     ranked = rank_candidates(deduped_pool, brief)
@@ -136,30 +137,6 @@ def _expansion_seed_candidates(ranked: list[ScoredCandidate], brief: ResearchBri
 def _must_include_hits(candidate: ScoredCandidate, brief: ResearchBrief) -> int:
     searchable_text = f"{candidate.title} {candidate.abstract} {candidate.snippet}".lower()
     return sum(1 for term in brief.must_include if term.lower() in searchable_text)
-
-
-def _enrich_top_candidates(
-    ranked: list[ScoredCandidate],
-    brief: ResearchBrief,
-    client: HttpClient,
-    warnings: list[str],
-) -> list[EnrichedCandidate]:
-    enriched: list[EnrichedCandidate] = []
-    for candidate in ranked:
-        result = enrich_candidate(candidate, brief, client)
-        enriched_candidate = EnrichedCandidate.from_paper_candidate(candidate.to_paper_candidate())
-        enriched_candidate.access_status = result.access_status
-        enriched_candidate.access_url = result.access_url
-        if not result.text:
-            if result.access_status == "unreadable":
-                warnings.append(f"no readable content found for {enriched_candidate.title}")
-            enriched.append(enriched_candidate)
-            continue
-        enriched_candidate.full_text = result.text
-        enriched_candidate.full_text_source = result.source
-        enriched_candidate.evidence = list(result.evidence)
-        enriched.append(enriched_candidate)
-    return enriched
 
 
 def _apply_llm_layer(ranked: list[EnrichedCandidate], brief: ResearchBrief, warnings: list[str]) -> str:

--- a/src/research_lab/enrichment.py
+++ b/src/research_lab/enrichment.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import dataclass
 
 from research_lab.lex import STOPWORDS, tokenize
-from research_lab.models import PaperCandidate, ResearchBrief, RetrievalCandidate
+from research_lab.models import EnrichedCandidate, PaperCandidate, ResearchBrief, RetrievalCandidate, ScoredCandidate
 from research_lab.sources.extraction import FullTextResult, fetch_candidate_full_text
 from research_lab.sources.transport import HttpClient, SourceError
 
@@ -178,3 +178,27 @@ def enrich_candidate(
         evidence=evidence,
         needs_user_article=needs_user_article(paper),
     )
+
+
+def enrich_candidates(
+    candidates: list[ScoredCandidate],
+    brief: ResearchBrief,
+    client: HttpClient,
+) -> tuple[list[EnrichedCandidate], list[str]]:
+    enriched: list[EnrichedCandidate] = []
+    warnings: list[str] = []
+    for candidate in candidates:
+        result = enrich_candidate(candidate, brief, client)
+        enriched_candidate = EnrichedCandidate.from_paper_candidate(candidate.to_paper_candidate())
+        enriched_candidate.access_status = result.access_status
+        enriched_candidate.access_url = result.access_url
+        if not result.text:
+            if result.access_status == "unreadable":
+                warnings.append(f"no readable content found for {enriched_candidate.title}")
+            enriched.append(enriched_candidate)
+            continue
+        enriched_candidate.full_text = result.text
+        enriched_candidate.full_text_source = result.source
+        enriched_candidate.evidence = list(result.evidence)
+        enriched.append(enriched_candidate)
+    return enriched, warnings

--- a/src/research_lab/rank.py
+++ b/src/research_lab/rank.py
@@ -4,7 +4,6 @@ from datetime import datetime, timezone
 import math
 import re
 
-from research_lab.enrichment import extract_evidence_sentences
 from research_lab.identity import candidates_match, normalize_title
 from research_lab.lex import STOPWORDS, tokenize
 from research_lab.models import PaperCandidate, ResearchBrief, RetrievalCandidate, ScoredCandidate

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -7,10 +7,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from research_lab.enrichment import (
     EnrichmentResult,
     enrich_candidate,
+    enrich_candidates,
     extract_evidence_sentences,
     needs_user_article,
 )
-from research_lab.models import PaperCandidate, ResearchBrief
+from research_lab.models import PaperCandidate, ResearchBrief, ScoredCandidate
 from research_lab.sources import HttpResponse, SourceError
 
 
@@ -247,6 +248,30 @@ class EnrichCandidateTests(unittest.TestCase):
         result = enrich_candidate(candidate, brief, _FailingClient())
 
         self.assertTrue(result.needs_user_article)
+
+    def test_enrich_candidates_collects_unreadable_warning(self) -> None:
+        candidate = ScoredCandidate(
+            title="Unreadable Candidate",
+            abstract="",
+            url="https://example.com/unreadable",
+            source="openalex",
+            source_id="oa:warn",
+            document_kind="paper",
+            source_names=["openalex"],
+            score=0.7,
+        )
+
+        class _FailingClient:
+            def fetch(self, url: str, headers: dict[str, str] | None = None) -> HttpResponse:
+                del headers
+                raise SourceError(f"request failed for {url}: network down")
+
+        brief = ResearchBrief(topic="test topic", context="test context")
+
+        enriched, warnings = enrich_candidates([candidate], brief, _FailingClient())
+
+        self.assertEqual(len(enriched), 1)
+        self.assertEqual(warnings, ["no readable content found for Unreadable Candidate"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- deepen document enrichment by moving batch enrichment and warning normalization into `enrichment.py`
- remove the shallow enrichment loop from `engine.py`
- keep access status, evidence extraction, and user-article semantics behind one enrichment seam

## Verification
- `python3 -m unittest discover -s tests`
- `PYTHONPATH=src python3 -m research_lab run --topic "AI coding agents for software engineering productivity" --context "I want strong academic papers, benchmarks, and useful industry blog posts or engineering explainers from labs and engineering teams." --iterations 1 --per-query 4 --web-per-query 4 --scholar-per-query 2 --full-text-top-n 6 --top-k 10`

Relates to #16