### PR TITLE
refactor: deepen final ranking module

### DIFF
--- a/src/research_lab/engine.py
+++ b/src/research_lab/engine.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from research_lab.enrichment import enrich_candidates
 from research_lab.identity import candidates_match
-from research_lab.llm import LlmClient, LlmError, rerank_candidates_with_llm, summarize_candidates_with_llm
+from research_lab.final_ranking import finalize_ranking
 from research_lab.models import EnrichedCandidate, PaperCandidate, QueryRecord, ResearchBrief, RetrievalCandidate, RunArtifacts, ScoredCandidate
 from research_lab.planner import build_expansion_queries, build_seed_queries
 from research_lab.rank import dedupe_candidates, rank_candidates
@@ -62,17 +62,17 @@ def execute_run(
     deduped_pool = dedupe_candidates(pool)
     ranked = rank_candidates(deduped_pool, brief)
     final_ranked = [EnrichedCandidate.from_paper_candidate(candidate) for candidate in _merge_scored_candidates(ranked, deduped_pool)]
-    synthesis = _apply_llm_layer(final_ranked, brief, warnings)
+    final_ranking = finalize_ranking(final_ranked, brief, warnings)
 
     artifacts = RunArtifacts.create(
         run_id=run_id,
         run_dir=str(run_dir),
         brief=brief,
         queries=all_queries,
-        candidates=[candidate.to_paper_candidate() for candidate in final_ranked],
+        candidates=[candidate.to_paper_candidate() for candidate in final_ranking.ranked],
         program_text=program_text,
         warnings=sorted(set(warnings)),
-        synthesis=synthesis,
+        synthesis=final_ranking.synthesis,
     )
     write_run_files(run_dir, artifacts)
     init_db(db_path)
@@ -138,33 +138,3 @@ def _must_include_hits(candidate: ScoredCandidate, brief: ResearchBrief) -> int:
     searchable_text = f"{candidate.title} {candidate.abstract} {candidate.snippet}".lower()
     return sum(1 for term in brief.must_include if term.lower() in searchable_text)
 
-
-def _apply_llm_layer(ranked: list[EnrichedCandidate], brief: ResearchBrief, warnings: list[str]) -> str:
-    client = LlmClient.from_env()
-    if client is None:
-        return ""
-
-    rerank_targets = ranked[: brief.llm_rerank_top_n]
-    if rerank_targets:
-        try:
-            reranked = rerank_candidates_with_llm(client, brief, rerank_targets)
-            for index, candidate in enumerate(rerank_targets, start=1):
-                candidate_id = f"c{index}"
-                result = reranked.get(candidate_id)
-                if result is None:
-                    continue
-                candidate.llm_score = result["score"]
-                candidate.llm_reasons = result["reasons"]
-                candidate.score = round(candidate.score + max(min(result["score"], 1.0), 0.0) * 0.25, 4)
-            ranked.sort(key=lambda item: (item.score, item.citation_count, item.year or 0), reverse=True)
-        except LlmError as exc:
-            warnings.append(str(exc))
-
-    summary_targets = ranked[: brief.llm_summary_top_n]
-    if not summary_targets:
-        return ""
-    try:
-        return summarize_candidates_with_llm(client, brief, summary_targets)
-    except LlmError as exc:
-        warnings.append(str(exc))
-        return ""

--- a/src/research_lab/final_ranking.py
+++ b/src/research_lab/final_ranking.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from research_lab.llm import LlmClient, LlmError, rerank_candidates_with_llm, summarize_candidates_with_llm
+from research_lab.models import EnrichedCandidate, ResearchBrief
+
+
+@dataclass(slots=True)
+class FinalRanking:
+    ranked: list[EnrichedCandidate]
+    high_confidence: list[EnrichedCandidate]
+    exploratory: list[EnrichedCandidate]
+    broad_intent: list[EnrichedCandidate]
+    synthesis: str = ""
+
+
+def finalize_ranking(
+    candidates: list[EnrichedCandidate],
+    brief: ResearchBrief,
+    warnings: list[str],
+) -> FinalRanking:
+    ranked = list(candidates)
+    synthesis = _apply_llm_layer(ranked, brief, warnings)
+    _sort_candidates(ranked)
+    ranking = group_final_ranking(ranked, brief)
+    ranking.synthesis = synthesis
+    return ranking
+
+
+def group_final_ranking(candidates: list[EnrichedCandidate], brief: ResearchBrief) -> FinalRanking:
+    ranked = list(candidates)
+    _sort_candidates(ranked)
+    top = ranked[: brief.top_k]
+    return FinalRanking(
+        ranked=ranked,
+        high_confidence=[candidate for candidate in top if candidate.score >= 0.35],
+        exploratory=[candidate for candidate in top if candidate.score < 0.35],
+        broad_intent=[candidate for candidate in top if is_broad_intent_match(candidate)],
+    )
+
+
+def is_broad_intent_match(candidate: EnrichedCandidate) -> bool:
+    return any(flag in {"survey_intent", "benchmark_intent", "foundational_intent"} for flag in candidate.flags)
+
+
+def _apply_llm_layer(ranked: list[EnrichedCandidate], brief: ResearchBrief, warnings: list[str]) -> str:
+    client = LlmClient.from_env()
+    if client is None:
+        return ""
+
+    rerank_targets = ranked[: brief.llm_rerank_top_n]
+    if rerank_targets:
+        try:
+            reranked = rerank_candidates_with_llm(client, brief, rerank_targets)
+            for index, candidate in enumerate(rerank_targets, start=1):
+                candidate_id = f"c{index}"
+                result = reranked.get(candidate_id)
+                if result is None:
+                    continue
+                candidate.llm_score = result["score"]
+                candidate.llm_reasons = result["reasons"]
+                candidate.score = round(candidate.score + max(min(result["score"], 1.0), 0.0) * 0.25, 4)
+            _sort_candidates(ranked)
+        except LlmError as exc:
+            warnings.append(str(exc))
+
+    summary_targets = ranked[: brief.llm_summary_top_n]
+    if not summary_targets:
+        return ""
+    try:
+        return summarize_candidates_with_llm(client, brief, summary_targets)
+    except LlmError as exc:
+        warnings.append(str(exc))
+        return ""
+
+
+def _sort_candidates(candidates: list[EnrichedCandidate]) -> None:
+    candidates.sort(key=lambda item: (item.score, item.citation_count, item.year or 0), reverse=True)

--- a/src/research_lab/report.py
+++ b/src/research_lab/report.py
@@ -4,7 +4,8 @@ import json
 from pathlib import Path
 
 from research_lab.enrichment import needs_user_article
-from research_lab.models import PaperCandidate, RunArtifacts
+from research_lab.final_ranking import group_final_ranking
+from research_lab.models import EnrichedCandidate, PaperCandidate, RunArtifacts
 from research_lab.web_result import CATEGORY_LABELS, collect_useful_web_sources, group_web_sources_by_category
 
 
@@ -49,11 +50,12 @@ def write_run_files(run_dir: Path, artifacts: RunArtifacts) -> None:
     bib = "\n".join(candidate_to_bibtex(candidate) for candidate in artifacts.candidates[: artifacts.brief.top_k])
     (run_dir / "references.bib").write_text(bib, encoding="utf-8")
 
-    top = artifacts.candidates[: artifacts.brief.top_k]
-    high_confidence = [candidate for candidate in top if candidate.score >= 0.35]
-    exploratory = [candidate for candidate in top if candidate.score < 0.35]
+    ranking = group_final_ranking([EnrichedCandidate.from_paper_candidate(candidate) for candidate in artifacts.candidates], artifacts.brief)
+    top = [candidate.to_paper_candidate() for candidate in ranking.ranked[: artifacts.brief.top_k]]
+    high_confidence = [candidate.to_paper_candidate() for candidate in ranking.high_confidence]
+    exploratory = [candidate.to_paper_candidate() for candidate in ranking.exploratory]
     requested_articles = [candidate for candidate in top if needs_user_article(candidate)]
-    broad_intent_matches = [candidate for candidate in top if _matches_broad_intent(candidate)]
+    broad_intent_matches = [candidate.to_paper_candidate() for candidate in ranking.broad_intent]
     useful_web_sources = collect_useful_web_sources(artifacts.candidates)
     web_groups = group_web_sources_by_category(useful_web_sources)
 
@@ -155,15 +157,6 @@ def _render_candidate(candidate: PaperCandidate) -> list[str]:
         label = "abstract" if candidate.abstract else "summary"
         lines.append(f"  - {label}: {summary}")
     return lines
-
-
-def _matches_broad_intent(candidate: PaperCandidate) -> bool:
-    broad_intent_flags = {
-        "survey_intent",
-        "benchmark_intent",
-        "foundational_intent",
-    }
-    return any(flag in broad_intent_flags for flag in candidate.flags)
 
 
 def _render_article_request(candidate: PaperCandidate) -> list[str]:

--- a/tests/test_final_ranking.py
+++ b/tests/test_final_ranking.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from research_lab.final_ranking import group_final_ranking, is_broad_intent_match
+from research_lab.models import EnrichedCandidate, ResearchBrief
+
+
+class FinalRankingTests(unittest.TestCase):
+    def test_group_final_ranking_builds_report_ready_groups(self) -> None:
+        brief = ResearchBrief(topic="graph neural networks", context="notes", top_k=3)
+        survey = EnrichedCandidate(
+            title="Survey",
+            abstract="A survey",
+            url="https://example.com/survey",
+            source="openalex",
+            source_id="oa:survey",
+            score=0.9,
+            flags=["survey_intent"],
+        )
+        lead = EnrichedCandidate(
+            title="Lead",
+            abstract="A paper",
+            url="https://example.com/lead",
+            source="openalex",
+            source_id="oa:lead",
+            score=0.6,
+        )
+        exploratory = EnrichedCandidate(
+            title="Exploratory",
+            abstract="A weaker paper",
+            url="https://example.com/exploratory",
+            source="openalex",
+            source_id="oa:exploratory",
+            score=0.2,
+        )
+
+        ranking = group_final_ranking([exploratory, survey, lead], brief)
+
+        self.assertEqual([candidate.title for candidate in ranking.ranked], ["Survey", "Lead", "Exploratory"])
+        self.assertEqual([candidate.title for candidate in ranking.high_confidence], ["Survey", "Lead"])
+        self.assertEqual([candidate.title for candidate in ranking.exploratory], ["Exploratory"])
+        self.assertEqual([candidate.title for candidate in ranking.broad_intent], ["Survey"])
+
+    def test_is_broad_intent_match_reads_flags(self) -> None:
+        candidate = EnrichedCandidate(
+            title="Benchmark",
+            abstract="Benchmark paper",
+            url="https://example.com/benchmark",
+            source="openalex",
+            source_id="oa:benchmark",
+            flags=["benchmark_intent"],
+        )
+
+        self.assertTrue(is_broad_intent_match(candidate))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- deepen final ranking behind a dedicated `final_ranking.py` module that owns final score composition, broad-intent classification, and report-ready candidate groups
- remove shallow final-ranking policy from `engine.py` and `report.py`
- add focused tests for the final ranking seam

## Verification
- `python3 -m unittest discover -s tests`
- `PYTHONPATH=src python3 -m research_lab run --topic "AI coding agents for software engineering productivity" --context "I want strong academic papers, benchmarks, and useful industry blog posts or engineering explainers from labs and engineering teams." --iterations 1 --per-query 4 --web-per-query 4 --scholar-per-query 2 --full-text-top-n 6 --top-k 10`

Closes #17