### PR TITLE
refactor: deepen report assembly module

### DIFF
--- a/src/research_lab/report.py
+++ b/src/research_lab/report.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from research_lab.enrichment import needs_user_article
-from research_lab.final_ranking import group_final_ranking
-from research_lab.models import EnrichedCandidate, PaperCandidate, RunArtifacts
-from research_lab.web_result import CATEGORY_LABELS, collect_useful_web_sources, group_web_sources_by_category
+from research_lab.models import PaperCandidate, RunArtifacts
+from research_lab.report_assembly import assemble_report
+from research_lab.web_result import CATEGORY_LABELS
 
 
 def write_json(path: Path, payload: object) -> None:
@@ -50,14 +49,7 @@ def write_run_files(run_dir: Path, artifacts: RunArtifacts) -> None:
     bib = "\n".join(candidate_to_bibtex(candidate) for candidate in artifacts.candidates[: artifacts.brief.top_k])
     (run_dir / "references.bib").write_text(bib, encoding="utf-8")
 
-    ranking = group_final_ranking([EnrichedCandidate.from_paper_candidate(candidate) for candidate in artifacts.candidates], artifacts.brief)
-    top = [candidate.to_paper_candidate() for candidate in ranking.ranked[: artifacts.brief.top_k]]
-    high_confidence = [candidate.to_paper_candidate() for candidate in ranking.high_confidence]
-    exploratory = [candidate.to_paper_candidate() for candidate in ranking.exploratory]
-    requested_articles = [candidate for candidate in top if needs_user_article(candidate)]
-    broad_intent_matches = [candidate.to_paper_candidate() for candidate in ranking.broad_intent]
-    useful_web_sources = collect_useful_web_sources(artifacts.candidates)
-    web_groups = group_web_sources_by_category(useful_web_sources)
+    assembly = assemble_report(artifacts)
 
     lines: list[str] = [
         f"# Research Run {artifacts.run_id}",
@@ -76,14 +68,14 @@ def write_run_files(run_dir: Path, artifacts: RunArtifacts) -> None:
         lines.extend(f"- {warning}" for warning in artifacts.warnings[:20])
     if artifacts.synthesis:
         lines.extend(["", "## LLM Synthesis", artifacts.synthesis])
-    if broad_intent_matches:
+    if assembly.broad_intent_matches:
         lines.extend(["", "## Broad Coverage Matches"])
-        for candidate in broad_intent_matches[:4]:
+        for candidate in assembly.broad_intent_matches[:4]:
             lines.extend(_render_candidate(candidate))
-    if useful_web_sources:
+    if assembly.useful_web_groups:
         lines.extend(["", "## Useful Web Sources"])
         for category in ("survey_support", "engineering_explainer", "general_web"):
-            group = web_groups.get(category, [])
+            group = assembly.useful_web_groups.get(category, [])
             if not group:
                 continue
             label = CATEGORY_LABELS.get(category, category)
@@ -91,22 +83,22 @@ def write_run_files(run_dir: Path, artifacts: RunArtifacts) -> None:
             for candidate in group[:4]:
                 lines.extend(_render_candidate(candidate))
     lines.extend(["", "## High Confidence Matches"])
-    if high_confidence:
-        for candidate in high_confidence:
+    if assembly.high_confidence:
+        for candidate in assembly.high_confidence:
             lines.extend(_render_candidate(candidate))
     else:
         lines.append("- No candidates crossed the high-confidence threshold.")
 
     lines.extend(["", "## Requested Articles From User"])
-    if requested_articles:
-        for candidate in requested_articles[:5]:
+    if assembly.requested_articles:
+        for candidate in assembly.requested_articles[:5]:
             lines.extend(_render_article_request(candidate))
     else:
         lines.append("- No paywalled or abstract-only papers need user retrieval in this run.")
 
     lines.extend(["", "## Lower Confidence Leads"])
-    if exploratory:
-        for candidate in exploratory[:10]:
+    if assembly.exploratory:
+        for candidate in assembly.exploratory[:10]:
             lines.extend(_render_candidate(candidate))
     else:
         lines.append("- No lower-confidence leads were retained.")

--- a/src/research_lab/report_assembly.py
+++ b/src/research_lab/report_assembly.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from research_lab.enrichment import needs_user_article
+from research_lab.final_ranking import FinalRanking, group_final_ranking
+from research_lab.models import EnrichedCandidate, PaperCandidate, RunArtifacts
+from research_lab.web_result import collect_useful_web_sources, group_web_sources_by_category
+
+
+@dataclass(slots=True)
+class ReportAssembly:
+    top: list[PaperCandidate]
+    high_confidence: list[PaperCandidate]
+    exploratory: list[PaperCandidate]
+    broad_intent_matches: list[PaperCandidate]
+    requested_articles: list[PaperCandidate]
+    useful_web_groups: dict[str, list[PaperCandidate]]
+
+
+def assemble_report(artifacts: RunArtifacts) -> ReportAssembly:
+    ranking = group_final_ranking(
+        [EnrichedCandidate.from_paper_candidate(candidate) for candidate in artifacts.candidates],
+        artifacts.brief,
+    )
+    top = _to_paper_candidates(ranking.ranked[: artifacts.brief.top_k])
+    useful_web_sources = collect_useful_web_sources(artifacts.candidates)
+    return ReportAssembly(
+        top=top,
+        high_confidence=_to_paper_candidates(ranking.high_confidence),
+        exploratory=_to_paper_candidates(ranking.exploratory),
+        broad_intent_matches=_to_paper_candidates(ranking.broad_intent),
+        requested_articles=[candidate for candidate in top if needs_user_article(candidate)],
+        useful_web_groups=group_web_sources_by_category(useful_web_sources),
+    )
+
+
+def _to_paper_candidates(candidates: list[EnrichedCandidate]) -> list[PaperCandidate]:
+    return [candidate.to_paper_candidate() for candidate in candidates]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -6,6 +6,7 @@ import unittest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from research_lab.models import PaperCandidate, ResearchBrief, RunArtifacts
+from research_lab.report_assembly import assemble_report
 from research_lab.report import write_run_files
 
 
@@ -113,6 +114,33 @@ class ReportTests(unittest.TestCase):
             self.assertIn("## Useful Web Sources", report)
             self.assertIn("Agentic Engineering Explained", report)
             self.assertIn("### ", report)
+
+    def test_assemble_report_groups_results(self) -> None:
+        brief = ResearchBrief(topic="graph neural networks", context="I want strong surveys.", top_k=3)
+        survey = PaperCandidate(
+            title="A compact review of graph neural networks",
+            abstract="A survey article.",
+            url="https://example.com/review",
+            source="openalex",
+            source_id="oa:review",
+            score=0.88,
+            flags=["survey_intent"],
+        )
+        web = PaperCandidate(
+            title="Agentic Engineering Explained",
+            abstract="A practical engineering explainer.",
+            url="https://example.com/blog",
+            source="duckduckgo",
+            source_id="web:blog",
+            document_kind="web",
+            score=0.44,
+        )
+        artifacts = RunArtifacts.create("run-5", "run-5", brief, [], [survey, web], "program")
+
+        assembly = assemble_report(artifacts)
+
+        self.assertEqual([candidate.title for candidate in assembly.broad_intent_matches], [survey.title])
+        self.assertIn("engineering_explainer", assembly.useful_web_groups)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- deepen report assembly by moving result-group classification into `report_assembly.py`
- make `report.py` presentation-only instead of recomputing broad-coverage, requested-article, and useful-web groups inline
- add focused tests for the report assembly seam

## Verification
- `python3 -m unittest discover -s tests`
- `PYTHONPATH=src python3 -m research_lab run --topic "AI coding agents for software engineering productivity" --context "I want strong academic papers, benchmarks, and useful industry blog posts or engineering explainers from labs and engineering teams." --iterations 1 --per-query 4 --web-per-query 4 --scholar-per-query 2 --full-text-top-n 6 --top-k 10`

Closes #20