### PR TITLE
refactor: deepen run history module

### DIFF
--- a/src/research_lab/cli.py
+++ b/src/research_lab/cli.py
@@ -8,7 +8,8 @@ from datetime import datetime
 from research_lab.briefs import load_brief_json, load_brief_markdown, write_brief_json
 from research_lab.engine import execute_run
 from research_lab.models import ResearchBrief
-from research_lab.review import compare_runs, find_previous_run_ref, load_run_snapshot, write_review_markdown
+from research_lab.review import compare_runs, write_review_markdown
+from research_lab.run_history import find_previous_run_ref, load_run_snapshot
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/research_lab/review.py
+++ b/src/research_lab/review.py
@@ -1,20 +1,11 @@
 from __future__ import annotations
 
-import json
-import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
 from research_lab.identity import candidates_match
 from research_lab.models import PaperCandidate, ResearchBrief
-
-
-@dataclass(slots=True)
-class RunSnapshot:
-    run_id: str
-    run_dir: Path
-    brief: ResearchBrief
-    candidates: list[PaperCandidate]
+from research_lab.run_history import RunSnapshot
 
 
 @dataclass(slots=True)
@@ -26,44 +17,6 @@ class ReviewResult:
     dropped_candidates: list[PaperCandidate]
     improved_candidates: list[tuple[PaperCandidate, PaperCandidate, float]]
     declined_candidates: list[tuple[PaperCandidate, PaperCandidate, float]]
-
-
-def load_run_snapshot(run_ref: str, runs_dir: Path) -> RunSnapshot:
-    run_path = Path(run_ref)
-    if not run_path.exists():
-        run_path = runs_dir / run_ref
-    if not run_path.exists() or not run_path.is_dir():
-        raise ValueError(f"run not found: {run_ref}")
-
-    brief = ResearchBrief.from_dict(_read_json(run_path / "brief.json"))
-    candidates = [PaperCandidate.from_dict(item) for item in _read_json(run_path / "candidates.json")]
-    return RunSnapshot(run_id=run_path.name, run_dir=run_path, brief=brief, candidates=candidates)
-
-
-def find_previous_run_ref(current: RunSnapshot, runs_dir: Path) -> str | None:
-    db_path = runs_dir / "index.sqlite3"
-    if db_path.exists():
-        connection = sqlite3.connect(db_path)
-        try:
-            row = connection.execute(
-                """
-                SELECT run_id
-                FROM runs
-                WHERE topic = ? AND run_id != ?
-                ORDER BY created_at DESC
-                LIMIT 1
-                """,
-                (current.brief.topic, current.run_id),
-            ).fetchone()
-            if row:
-                return str(row[0])
-        finally:
-            connection.close()
-
-    sibling_runs = sorted(path.name for path in runs_dir.iterdir() if path.is_dir() and path.name != current.run_id)
-    return sibling_runs[-1] if sibling_runs else None
-
-
 def compare_runs(current: RunSnapshot, baseline: RunSnapshot, top_k: int) -> ReviewResult:
     current_top = current.candidates[:top_k]
     baseline_top = baseline.candidates[:top_k]
@@ -160,14 +113,6 @@ def write_review_markdown(result: ReviewResult, output_path: Path, top_k: int) -
         lines.append("- none")
 
     output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-
-def _read_json(path: Path) -> object:
-    if not path.exists():
-        raise ValueError(f"missing artifact: {path}")
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
 def _find_matching_candidate_index(
     candidate: PaperCandidate,
     pool: list[PaperCandidate],

--- a/src/research_lab/run_history.py
+++ b/src/research_lab/run_history.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from research_lab.models import PaperCandidate, ResearchBrief
+
+
+@dataclass(slots=True)
+class RunSnapshot:
+    run_id: str
+    run_dir: Path
+    brief: ResearchBrief
+    candidates: list[PaperCandidate]
+
+
+def load_run_snapshot(run_ref: str, runs_dir: Path) -> RunSnapshot:
+    run_path = Path(run_ref)
+    if not run_path.exists():
+        run_path = runs_dir / run_ref
+    if not run_path.exists() or not run_path.is_dir():
+        raise ValueError(f"run not found: {run_ref}")
+
+    brief = ResearchBrief.from_dict(_read_json(run_path / "brief.json"))
+    candidates = [PaperCandidate.from_dict(item) for item in _read_json(run_path / "candidates.json")]
+    return RunSnapshot(run_id=run_path.name, run_dir=run_path, brief=brief, candidates=candidates)
+
+
+def find_previous_run_ref(current: RunSnapshot, runs_dir: Path) -> str | None:
+    db_path = runs_dir / "index.sqlite3"
+    if db_path.exists():
+        connection = sqlite3.connect(db_path)
+        try:
+            row = connection.execute(
+                """
+                SELECT run_id
+                FROM runs
+                WHERE topic = ? AND run_id != ?
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                (current.brief.topic, current.run_id),
+            ).fetchone()
+            if row:
+                return str(row[0])
+        finally:
+            connection.close()
+
+    sibling_runs = sorted(path.name for path in runs_dir.iterdir() if path.is_dir() and path.name != current.run_id)
+    return sibling_runs[-1] if sibling_runs else None
+
+
+def _read_json(path: Path) -> object:
+    if not path.exists():
+        raise ValueError(f"missing artifact: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -6,8 +6,9 @@ import unittest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from research_lab.models import PaperCandidate, ResearchBrief
-from research_lab.review import compare_runs, find_previous_run_ref, load_run_snapshot, write_review_markdown
+from research_lab.review import compare_runs, write_review_markdown
 from research_lab.report import write_json
+from research_lab.run_history import find_previous_run_ref, load_run_snapshot
 from research_lab.store import init_db, record_run
 from research_lab.models import RunArtifacts
 


### PR DESCRIPTION
## Summary
- deepen run history by moving snapshot loading and baseline selection into `run_history.py`
- leave `review.py` focused on comparison and markdown rendering
- update CLI and tests to depend on the run history seam instead of the review module for storage-backed loading

## Verification
- `python3 -m unittest discover -s tests`
- `PYTHONPATH=src python3 -m research_lab review --run runs/20260430-080437-graph-neural-networks-for-molecular-property-prediction --runs-dir runs`

Closes #18