### PR TITLE
refactor: deepen web result module

### DIFF
--- a/src/research_lab/report_assembly.py
+++ b/src/research_lab/report_assembly.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from research_lab.enrichment import needs_user_article
 from research_lab.final_ranking import FinalRanking, group_final_ranking
 from research_lab.models import EnrichedCandidate, PaperCandidate, RunArtifacts
-from research_lab.web_result import collect_useful_web_sources, group_web_sources_by_category
+from research_lab.web_result import assemble_web_results
 
 
 @dataclass(slots=True)
@@ -24,14 +24,14 @@ def assemble_report(artifacts: RunArtifacts) -> ReportAssembly:
         artifacts.brief,
     )
     top = _to_paper_candidates(ranking.ranked[: artifacts.brief.top_k])
-    useful_web_sources = collect_useful_web_sources(artifacts.candidates)
+    web_results = assemble_web_results(artifacts.candidates)
     return ReportAssembly(
         top=top,
         high_confidence=_to_paper_candidates(ranking.high_confidence),
         exploratory=_to_paper_candidates(ranking.exploratory),
         broad_intent_matches=_to_paper_candidates(ranking.broad_intent),
         requested_articles=[candidate for candidate in top if needs_user_article(candidate)],
-        useful_web_groups=group_web_sources_by_category(useful_web_sources),
+        useful_web_groups=web_results.grouped_sources,
     )
 
 

--- a/src/research_lab/web_result.py
+++ b/src/research_lab/web_result.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from research_lab.models import PaperCandidate
 
 
@@ -129,3 +131,17 @@ CATEGORY_LABELS: dict[str, str] = {
     "engineering_explainer": "Engineering Explainers & Tutorials",
     "general_web": "General Web Sources",
 }
+
+
+@dataclass(slots=True)
+class WebResultAssembly:
+    useful_sources: list[PaperCandidate]
+    grouped_sources: dict[str, list[PaperCandidate]]
+
+
+def assemble_web_results(candidates: list[PaperCandidate], limit: int = 6) -> WebResultAssembly:
+    useful_sources = collect_useful_web_sources(candidates, limit=limit)
+    return WebResultAssembly(
+        useful_sources=useful_sources,
+        grouped_sources=group_web_sources_by_category(useful_sources),
+    )

--- a/tests/test_web_result.py
+++ b/tests/test_web_result.py
@@ -7,6 +7,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from research_lab.models import PaperCandidate
 from research_lab.web_result import (
     CATEGORY_LABELS,
+    WebResultAssembly,
+    assemble_web_results,
     classify_web_source,
     collect_useful_web_sources,
     group_web_sources_by_category,
@@ -265,6 +267,37 @@ class GroupWebSourcesByCategoryTests(unittest.TestCase):
     def test_category_labels_cover_all_categories(self) -> None:
         for cat in ("survey_support", "engineering_explainer", "general_web"):
             self.assertIn(cat, CATEGORY_LABELS)
+
+
+class AssembleWebResultsTests(unittest.TestCase):
+    def test_assemble_web_results_returns_useful_and_grouped_views(self) -> None:
+        survey = PaperCandidate(
+            title="A Survey of LLM Techniques",
+            abstract="overview",
+            url="https://example.com/survey",
+            source="duckduckgo",
+            source_id="web:survey",
+            document_kind="web",
+            score=0.30,
+            source_names=["duckduckgo"],
+        )
+        explainer = PaperCandidate(
+            title="Getting Started with LLMs",
+            abstract="tutorial",
+            url="https://huggingface.co/blog/llms",
+            source="duckduckgo",
+            source_id="web:explainer",
+            document_kind="web",
+            score=0.25,
+            source_names=["duckduckgo"],
+        )
+
+        assembly = assemble_web_results([survey, explainer])
+
+        self.assertIsInstance(assembly, WebResultAssembly)
+        self.assertEqual([candidate.title for candidate in assembly.useful_sources], [survey.title, explainer.title])
+        self.assertIn("survey_support", assembly.grouped_sources)
+        self.assertIn("engineering_explainer", assembly.grouped_sources)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- deepen web-result surfacing behind a dedicated web-result assembly interface instead of separate collection and grouping helpers
- update report assembly to consume one web-result seam
- add focused tests for the assembled web-result view

## Verification
- `python3 -m unittest discover -s tests`
- `PYTHONPATH=src python3 -m research_lab run --topic "AI coding agents for software engineering productivity" --context "I want strong academic papers, benchmarks, and useful industry blog posts or engineering explainers from labs and engineering teams." --iterations 1 --per-query 4 --web-per-query 4 --scholar-per-query 2 --full-text-top-n 6 --top-k 10`

Closes #19