### PR TITLE
docs(readme): sync GitHub Agent section with actual opencode workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,16 +184,16 @@ If the LLM call fails or is not configured, the run still completes with heurist
 
 ## GitHub Agent
 
-This repo also includes a GitHub Actions workflow at `.github/workflows/opencode.yml` that lets OpenCode respond to GitHub comments.
+This repo includes a GitHub Actions workflow at `.github/workflows/opencode.yml` that lets OpenCode respond to GitHub comments.
 
-It can handle:
+It is triggered by:
 
-- issue comments
-- PR conversation comments
-- inline PR review comments in `Files changed`
-- submitted PR reviews with a body
+- **Issue comments** – comment on any issue or PR conversation
+- **PR review comments** – comment on specific code lines in a PR's `Files changed` tab
 
-Typical commands are:
+Typing `/oc` or `/opencode` in a new comment on either of those surfaces will start the agent. Editing an old comment will not trigger the workflow.
+
+Typical commands:
 
 ```text
 /opencode explain this issue
@@ -202,15 +202,16 @@ Typical commands are:
 /oc address these review comments
 ```
 
-The workflow is configured to use `GITHUB_TOKEN`, so the agent can reply on issues and PRs, push commits, and open or update PRs when the action decides that is appropriate.
+The workflow authenticates via the [OpenCode GitHub App](https://github.com/apps/opencode-agent). Install the app on the target repository before using the workflow. The agent can reply on issues and PRs, push commits, and open or update PRs when the action decides that is appropriate.
 
-To use it, make sure:
+To set it up:
 
-- the `opencode` workflow exists in `.github/workflows/opencode.yml`
-- the `SIEMENS_LLM_API_KEY` secret is configured in GitHub Actions secrets
-- GitHub Actions are enabled for the repository
+1. Install the **OpenCode Agent** GitHub App from <https://github.com/apps/opencode-agent> and grant it access to the repository.
+2. Ensure the `opencode` workflow exists in `.github/workflows/opencode.yml`.
+3. Configure the `SIEMENS_LLM_API_KEY` secret in GitHub Actions secrets.
+4. Enable GitHub Actions for the repository.
 
-Then create a new GitHub comment containing `/oc` or `/opencode`. Editing an old comment will not trigger the workflow.
+Then create a new comment containing `/oc` or `/opencode`.
 
 ## OpenCode Prompts
 


### PR DESCRIPTION
## Summary

The README's "GitHub Agent" section described triggers and authentication that no longer match the live workflow:

- **Triggers**: README claimed submitted PR reviews with a body are handled. The workflow only listens to `issue_comment` and `pull_request_review_comment`.
- **Auth**: README said the workflow uses `GITHUB_TOKEN`. The live workflow authenticates via the installed OpenCode GitHub App and does not pass `GITHUB_TOKEN` into the action.

This PR updates the section to describe what the workflow actually does, and corrects the setup instructions to mention the GitHub App installation step.

## Tests run

- Read through the updated section for internal consistency.
- Verified the trigger list matches `.github/workflows/opencode.yml` lines 5–9.
- Verified the auth description matches the action invocation (no `GITHUB_TOKEN`/`token`/`use_github_token` inputs).

Closes #31