### PR TITLE
refactor(architecture): deepen research lab seams

### DIFF
--- a/src/research_lab/document_access.py
+++ b/src/research_lab/document_access.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from research_lab.models import Candidate
+from research_lab.sources.extraction import FullTextResult, _classify_fetch_error, _classify_html_access, _extract_text_from_pdf_bytes
+from research_lab.sources.transport import HttpClient, SourceError
+
+
+class DocumentAccessResolver:
+    def __init__(self, client: HttpClient) -> None:
+        self.client = client
+
+    def fetch(self, candidate: Candidate) -> FullTextResult:
+        last_result = FullTextResult(text="", source="", access_status="", access_url="")
+        last_error: SourceError | None = None
+        for url in self._candidate_urls(candidate):
+            try:
+                response = self.client.fetch(url, headers={"Accept": "text/html,application/pdf;q=0.9,*/*;q=0.8"})
+            except SourceError as exc:
+                last_result = _classify_fetch_error(url, exc)
+                last_error = exc
+                continue
+            content_type = response.content_type.lower()
+            if "pdf" in content_type or response.final_url.lower().endswith(".pdf") or url.lower().endswith(".pdf"):
+                text = _extract_text_from_pdf_bytes(response.body)
+                if text:
+                    return FullTextResult(text=text, source="pdf", access_status="open", access_url=response.final_url)
+                last_result = FullTextResult(text="", source="", access_status="unreadable", access_url=response.final_url)
+                continue
+            result = _classify_html_access(candidate, response)
+            if result.text:
+                return result
+            last_result = result
+        if last_result.access_status:
+            return last_result
+        if last_error is not None:
+            raise last_error
+        raise SourceError(f"no reachable content found for {candidate.title}")
+
+    def _candidate_urls(self, candidate: Candidate) -> list[str]:
+        return [url for url in [candidate.open_access_url, candidate.url] if url]

--- a/src/research_lab/engine.py
+++ b/src/research_lab/engine.py
@@ -1,18 +1,9 @@
 from __future__ import annotations
 
-from collections import Counter
 from pathlib import Path
 
-from research_lab.enrichment import enrich_candidates
-from research_lab.identity import candidates_match
-from research_lab.final_ranking import finalize_ranking
-from research_lab.models import Candidate, QueryRecord, ResearchBrief, RunArtifacts
-from research_lab.planner import build_expansion_queries, build_seed_queries
-from research_lab.rank import dedupe_candidates, rank_candidates
-from research_lab.report import write_run_files
-from research_lab.retrieval import RetrievalPolicy
-from research_lab.sources import HttpClient
-from research_lab.store import init_db, record_run
+from research_lab.models import ResearchBrief, RunArtifacts
+from research_lab.search_session import SearchSession, expansion_seed_candidates
 
 
 def execute_run(
@@ -22,119 +13,9 @@ def execute_run(
     run_dir: Path,
     db_path: Path,
 ) -> RunArtifacts:
-    client = HttpClient()
-    retrieval = RetrievalPolicy(client=client, scholar_per_query=brief.scholar_per_query)
-    all_queries: list[QueryRecord] = []
-    seen_query_strings: set[str] = set()
-    pool: list[Candidate] = []
-    warnings: list[str] = retrieval.warnings
-
-    seed_queries = build_seed_queries(brief)
-    for query in seed_queries:
-        _add_query(query, all_queries, seen_query_strings)
-        pool.extend(retrieval.search(query, brief))
-
-    ranked = rank_candidates(dedupe_candidates(pool), brief)
-
-    for iteration in range(1, brief.iterations + 1):
-        seed_candidates = _expansion_seed_candidates(ranked, brief)
-        top_titles = [candidate.title for candidate in seed_candidates[:3]]
-        top_authors = _top_authors(seed_candidates)
-        expansion_queries = build_expansion_queries(brief, top_titles, top_authors, iteration)
-
-        expanded_pool: list[Candidate] = []
-        for query in expansion_queries:
-            if not _add_query(query, all_queries, seen_query_strings):
-                continue
-            expanded_pool.extend(retrieval.search(query, brief))
-
-        for candidate in seed_candidates[:2]:
-            expanded_pool.extend(retrieval.fetch_references(candidate, brief.per_query))
-
-        if not expanded_pool:
-            continue
-        pool.extend(expanded_pool)
-        ranked = rank_candidates(dedupe_candidates(pool), brief)
-
-    enriched, enrichment_warnings = enrich_candidates(ranked[: brief.full_text_top_n], brief, client)
-    warnings.extend(enrichment_warnings)
-    pool.extend(enriched)
-    deduped_pool = dedupe_candidates(pool)
-    ranked = rank_candidates(deduped_pool, brief)
-    final_ranked = _merge_scored_candidates(ranked, deduped_pool)
-    final_ranking = finalize_ranking(final_ranked, brief, warnings)
-
-    artifacts = RunArtifacts.create(
-        run_id=run_id,
-        run_dir=str(run_dir),
-        brief=brief,
-        queries=all_queries,
-        candidates=final_ranking.ranked,
-        program_text=program_text,
-        warnings=sorted(set(warnings)),
-        synthesis=final_ranking.synthesis,
-    )
-    write_run_files(run_dir, artifacts)
-    init_db(db_path)
-    record_run(db_path, artifacts)
-    return artifacts
+    session = SearchSession(brief)
+    return session.execute(run_id=run_id, run_dir=run_dir, db_path=db_path, program_text=program_text)
 
 
-def _add_query(query: QueryRecord, all_queries: list[QueryRecord], seen: set[str]) -> bool:
-    lowered = query.query.lower()
-    if lowered in seen:
-        return False
-    seen.add(lowered)
-    all_queries.append(query)
-    return True
-
-
-def _top_authors(candidates: list[Candidate]) -> list[str]:
-    counts = Counter(author for candidate in candidates for author in candidate.authors[:3] if author)
-    return [author for author, _ in counts.most_common(3)]
-
-
-def _merge_scored_candidates(ranked: list[Candidate], pool: list[Candidate]) -> list[Candidate]:
-    merged: list[Candidate] = []
-    used_indices: set[int] = set()
-    for scored_candidate in ranked:
-        for index, candidate in enumerate(pool):
-            if index in used_indices:
-                continue
-            if not candidates_match(scored_candidate, candidate):
-                continue
-            candidate.score = scored_candidate.score
-            candidate.reasons = list(scored_candidate.reasons)
-            candidate.flags = list(scored_candidate.flags)
-            merged.append(candidate)
-            used_indices.add(index)
-            break
-    return merged
-
-
-def _expansion_seed_candidates(ranked: list[Candidate], brief: ResearchBrief) -> list[Candidate]:
-    required_hits = 0
-    if brief.must_include:
-        required_hits = 1 if len(brief.must_include) <= 2 else 2
-
-    filtered = [
-        candidate
-        for candidate in ranked
-        if candidate.document_kind == "paper"
-        and candidate.score >= 0.45
-        and _must_include_hits(candidate, brief) >= required_hits
-        and not any(flag in {"drift", "weak_title"} for flag in candidate.flags)
-    ]
-    if filtered:
-        return filtered[:3]
-
-    papers = [candidate for candidate in ranked if candidate.document_kind == "paper"]
-    if papers:
-        return papers[:3]
-    return ranked[:3]
-
-
-def _must_include_hits(candidate: Candidate, brief: ResearchBrief) -> int:
-    searchable_text = f"{candidate.title} {candidate.abstract} {candidate.snippet}".lower()
-    return sum(1 for term in brief.must_include if term.lower() in searchable_text)
-
+def _expansion_seed_candidates(ranked, brief: ResearchBrief):
+    return expansion_seed_candidates(ranked, brief)

--- a/src/research_lab/enrichment.py
+++ b/src/research_lab/enrichment.py
@@ -4,9 +4,10 @@ import re
 
 from dataclasses import dataclass
 
+from research_lab.document_access import DocumentAccessResolver
 from research_lab.lex import STOPWORDS, tokenize
 from research_lab.models import Candidate, ResearchBrief
-from research_lab.sources.extraction import FullTextResult, fetch_candidate_full_text
+from research_lab.sources.extraction import FullTextResult
 from research_lab.sources.transport import HttpClient, SourceError
 
 
@@ -143,8 +144,9 @@ def enrich_candidate(
     brief: ResearchBrief,
     client: HttpClient,
 ) -> EnrichmentResult:
+    resolver = DocumentAccessResolver(client)
     try:
-        result = fetch_candidate_full_text(candidate, client)
+        result = resolver.fetch(candidate)
     except SourceError:
         return EnrichmentResult(
             text="",

--- a/src/research_lab/rank.py
+++ b/src/research_lab/rank.py
@@ -165,22 +165,21 @@ def _add_flag(flags: list[str], flag: str) -> None:
         flags.append(flag)
 
 
-def score_candidate(candidate: Candidate, brief: ResearchBrief) -> Candidate:
-    candidate = candidate.copy()
-    topic_terms = _keyword_set(brief.topic)
-    context_terms = _keyword_set(brief.context)
-    title_terms = _keyword_set(candidate.title)
-    abstract_terms = _keyword_set(candidate.abstract or candidate.snippet)
-    full_text_terms = _keyword_set(candidate.full_text)
-    text_terms = title_terms | abstract_terms | full_text_terms
-    topic_bigrams = _bigram_set(brief.topic)
-    text_bigrams = _bigram_set(f"{candidate.title} {candidate.abstract} {candidate.full_text}")
-    topic_facets = _topic_facets(brief.topic)
-    searchable_text = f"{candidate.title} {candidate.abstract} {candidate.snippet} {candidate.full_text}"
-    searchable_norm = normalize_title(searchable_text)
-    searchable_lower = searchable_text.lower()
-    title_norm = normalize_title(candidate.title)
-
+def _score_topic_alignment(
+    candidate: Candidate,
+    brief: ResearchBrief,
+    topic_terms: set[str],
+    title_terms: set[str],
+    abstract_terms: set[str],
+    full_text_terms: set[str],
+    text_terms: set[str],
+    topic_bigrams: set[str],
+    text_bigrams: set[str],
+    topic_facets: list[str],
+    searchable_text: str,
+    searchable_norm: str,
+    title_norm: str,
+) -> tuple[float, list[str], list[str]]:
     score = 0.0
     reasons: list[str] = []
     flags: list[str] = []
@@ -226,12 +225,44 @@ def score_candidate(candidate: Candidate, brief: ResearchBrief) -> Candidate:
         if len(topic_facets) > 1 and covered_facets < len(topic_facets):
             score -= (len(topic_facets) - covered_facets) * 0.04
 
+    return score, reasons, flags
+
+
+def _score_context_alignment(
+    candidate: Candidate,
+    brief: ResearchBrief,
+    context_terms: set[str],
+    text_terms: set[str],
+    searchable_lower: str,
+    title_norm: str,
+) -> tuple[float, list[str], list[str]]:
+    score = 0.0
+    reasons: list[str] = []
+    flags: list[str] = []
+
     context_overlap = len(context_terms & text_terms)
     if context_terms:
         context_ratio = context_overlap / len(context_terms)
         score += min(context_ratio, 0.4) * 0.2
         if context_overlap:
             reasons.append(f"context overlap {context_overlap}/{len(context_terms)}")
+
+    if title_norm and title_norm in normalize_title(brief.context):
+        score -= 0.08
+        reasons.append("already mentioned in context")
+
+    intent_bonus, intent_reasons, intent_flags = _context_intent_bonus(candidate, brief, searchable_lower)
+    score += intent_bonus
+    reasons.extend(intent_reasons)
+    for flag in intent_flags:
+        _add_flag(flags, flag)
+
+    return score, reasons, flags
+
+
+def _score_metadata(candidate: Candidate) -> tuple[float, list[str], list[str]]:
+    score = 0.0
+    reasons: list[str] = []
 
     if candidate.abstract:
         score += 0.05
@@ -276,16 +307,30 @@ def score_candidate(candidate: Candidate, brief: ResearchBrief) -> Candidate:
         score -= 0.08
         reasons.append("light metadata")
 
+    return score, reasons, []
+
+
+def _score_evidence(candidate: Candidate) -> tuple[float, list[str], list[str]]:
+    score = 0.0
+    reasons: list[str] = []
     if candidate.full_text:
         score += 0.03
         reasons.append("full text fetched")
     if candidate.evidence:
         score += min(len(candidate.evidence), 3) * 0.03
         reasons.append(f"{len(candidate.evidence)} evidence snippets")
+    return score, reasons, []
 
-    if title_norm and title_norm in normalize_title(brief.context):
-        score -= 0.08
-        reasons.append("already mentioned in context")
+
+def _score_constraints(
+    brief: ResearchBrief,
+    topic_terms: set[str],
+    text_terms: set[str],
+    searchable_lower: str,
+) -> tuple[float, list[str], list[str]]:
+    score = 0.0
+    reasons: list[str] = []
+    flags: list[str] = []
 
     if brief.must_include:
         include_hits = sum(1 for term in brief.must_include if term.lower() in searchable_lower)
@@ -311,11 +356,54 @@ def score_candidate(candidate: Candidate, brief: ResearchBrief) -> Candidate:
     if any("drift" in reason for reason in mismatch_reasons):
         _add_flag(flags, "drift")
 
-    intent_bonus, intent_reasons, intent_flags = _context_intent_bonus(candidate, brief, searchable_lower)
-    score += intent_bonus
-    reasons.extend(intent_reasons)
-    for flag in intent_flags:
-        _add_flag(flags, flag)
+    return score, reasons, flags
+
+
+def score_candidate(candidate: Candidate, brief: ResearchBrief) -> Candidate:
+    candidate = candidate.copy()
+    topic_terms = _keyword_set(brief.topic)
+    context_terms = _keyword_set(brief.context)
+    title_terms = _keyword_set(candidate.title)
+    abstract_terms = _keyword_set(candidate.abstract or candidate.snippet)
+    full_text_terms = _keyword_set(candidate.full_text)
+    text_terms = title_terms | abstract_terms | full_text_terms
+    topic_bigrams = _bigram_set(brief.topic)
+    text_bigrams = _bigram_set(f"{candidate.title} {candidate.abstract} {candidate.full_text}")
+    topic_facets = _topic_facets(brief.topic)
+    searchable_text = f"{candidate.title} {candidate.abstract} {candidate.snippet} {candidate.full_text}"
+    searchable_norm = normalize_title(searchable_text)
+    searchable_lower = searchable_text.lower()
+    title_norm = normalize_title(candidate.title)
+
+    score = 0.0
+    reasons: list[str] = []
+    flags: list[str] = []
+
+    for signal_score, signal_reasons, signal_flags in [
+        _score_topic_alignment(
+            candidate,
+            brief,
+            topic_terms,
+            title_terms,
+            abstract_terms,
+            full_text_terms,
+            text_terms,
+            topic_bigrams,
+            text_bigrams,
+            topic_facets,
+            searchable_text,
+            searchable_norm,
+            title_norm,
+        ),
+        _score_context_alignment(candidate, brief, context_terms, text_terms, searchable_lower, title_norm),
+        _score_metadata(candidate),
+        _score_evidence(candidate),
+        _score_constraints(brief, topic_terms, text_terms, searchable_lower),
+    ]:
+        score += signal_score
+        reasons.extend(signal_reasons)
+        for flag in signal_flags:
+            _add_flag(flags, flag)
 
     candidate.score = round(score, 4)
     candidate.reasons = reasons

--- a/src/research_lab/retrieval.py
+++ b/src/research_lab/retrieval.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import os
+from collections.abc import MutableMapping
 
 from research_lab.models import Candidate, QueryRecord, ResearchBrief
+from research_lab.retrieval_plan import RetrievalPlan
 from research_lab.sources import (
     HttpClient,
     SourceError,
@@ -20,21 +22,17 @@ class RetrievalPolicy:
         semantic_scholar_api_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY", "").strip()
         self.client = client or HttpClient()
         self.warnings: list[str] = []
-        self._state: dict[str, object] = {
-            "arxiv_enabled": True,
-            "arxiv_requests_remaining": 6,
-            "semanticscholar_enabled": bool(semantic_scholar_api_key),
-            "semanticscholar_has_api_key": bool(semantic_scholar_api_key),
-            "semanticscholar_requests_remaining": 999 if semantic_scholar_api_key else 0,
-            "googlescholar_enabled": scholar_per_query > 0,
-            "googlescholar_requests_remaining": 3 if scholar_per_query > 0 else 0,
-        }
+        self.plan = RetrievalPlan(
+            has_semantic_scholar_api_key=bool(semantic_scholar_api_key),
+            scholar_per_query=scholar_per_query,
+        )
+        self._state = _RetrievalStateView(self.plan)
 
     def search(self, query: QueryRecord, brief: ResearchBrief) -> list[Candidate]:
         collected: list[Candidate] = []
-        if self._should_use_arxiv(query):
+        if self.plan.should_use_arxiv(query):
             try:
-                self._state["arxiv_requests_remaining"] = int(self._state["arxiv_requests_remaining"]) - 1
+                self.plan.arxiv.consume()
                 collected.extend(self._annotate(query, search_arxiv(query.query, brief.per_query, brief.since_year, self.client)))
             except SourceError as exc:
                 self._handle_arxiv_error(exc)
@@ -42,9 +40,9 @@ class RetrievalPolicy:
             collected.extend(self._annotate(query, search_openalex(query.query, brief.per_query, brief.since_year, self.client)))
         except SourceError as exc:
             self.warnings.append(str(exc))
-        if self._should_use_semantic_scholar(query):
+        if self.plan.should_use_semantic_scholar(query):
             try:
-                self._state["semanticscholar_requests_remaining"] = int(self._state["semanticscholar_requests_remaining"]) - 1
+                self.plan.semantic_scholar.consume()
                 collected.extend(self._annotate(query, search_semantic_scholar(query.query, brief.per_query, brief.since_year, self.client)))
             except SourceError as exc:
                 self._handle_semantic_scholar_error(exc)
@@ -52,21 +50,21 @@ class RetrievalPolicy:
             collected.extend(self._annotate(query, search_duckduckgo(query.query, brief.web_per_query, self.client)))
         except SourceError as exc:
             self.warnings.append(str(exc))
-        if self._should_use_google_scholar(query):
+        if self.plan.should_use_google_scholar(query):
             try:
-                self._state["googlescholar_requests_remaining"] = int(self._state["googlescholar_requests_remaining"]) - 1
+                self.plan.google_scholar.consume()
                 collected.extend(self._annotate(query, search_google_scholar(query.query, brief.scholar_per_query, self.client)))
             except SourceError as exc:
                 self._handle_google_scholar_error(exc)
         return collected
 
     def fetch_references(self, candidate: Candidate, per_query: int) -> list[Candidate]:
-        if not self._should_use_semantic_scholar(None):
+        if not self.plan.should_use_semantic_scholar(None):
             return []
         if not candidate.source_id or not candidate.source.startswith("semanticscholar"):
             return []
         try:
-            self._state["semanticscholar_requests_remaining"] = int(self._state["semanticscholar_requests_remaining"]) - 1
+            self.plan.semantic_scholar.consume()
             references = fetch_semantic_scholar_references(candidate.source_id, per_query, self.client)
         except SourceError as exc:
             self._handle_semantic_scholar_error(exc)
@@ -83,49 +81,46 @@ class RetrievalPolicy:
     def _handle_arxiv_error(self, exc: SourceError) -> None:
         message = str(exc)
         if "HTTP Error 429" in message or "timed out" in message:
-            if self._state["arxiv_enabled"]:
+            if self.plan.arxiv.enabled:
                 self.warnings.append("arxiv disabled after rate limit")
-            self._state["arxiv_enabled"] = False
+            self.plan.arxiv.disable()
             return
         self.warnings.append(message)
 
     def _handle_semantic_scholar_error(self, exc: SourceError) -> None:
         if "HTTP Error 429" in str(exc):
-            if self._state["semanticscholar_enabled"]:
+            if self.plan.semantic_scholar.enabled:
                 self.warnings.append("semantic scholar disabled after rate limit")
-            self._state["semanticscholar_enabled"] = False
+            self.plan.semantic_scholar.disable()
             return
         self.warnings.append(str(exc))
 
     def _handle_google_scholar_error(self, exc: SourceError) -> None:
         if "google scholar blocked automated access" in str(exc):
-            if self._state["googlescholar_enabled"]:
+            if self.plan.google_scholar.enabled:
                 self.warnings.append("google scholar disabled after block")
-            self._state["googlescholar_enabled"] = False
+            self.plan.google_scholar.disable()
             return
         self.warnings.append(str(exc))
 
-    def _should_use_arxiv(self, query: QueryRecord) -> bool:
-        if not self._state["arxiv_enabled"]:
-            return False
-        if int(self._state["arxiv_requests_remaining"]) <= 0:
-            return False
-        return query.origin not in {"author_expansion", "title_expansion"}
 
-    def _should_use_semantic_scholar(self, query: QueryRecord | None) -> bool:
-        if not self._state["semanticscholar_enabled"]:
-            return False
-        if int(self._state["semanticscholar_requests_remaining"]) <= 0:
-            return False
-        if bool(self._state["semanticscholar_has_api_key"]):
-            return True
-        if query is None:
-            return True
-        return query.origin not in {"author_expansion", "title_expansion"}
+class _RetrievalStateView(MutableMapping[str, object]):
+    def __init__(self, plan: RetrievalPlan) -> None:
+        self.plan = plan
 
-    def _should_use_google_scholar(self, query: QueryRecord) -> bool:
-        if not self._state["googlescholar_enabled"]:
-            return False
-        if int(self._state["googlescholar_requests_remaining"]) <= 0:
-            return False
-        return query.origin not in {"author_expansion", "title_expansion"}
+    def __getitem__(self, key: str) -> object:
+        return self.plan.state()[key]
+
+    def __setitem__(self, key: str, value: object) -> None:
+        state = self.plan.state()
+        state[key] = value
+        self.plan.load_state(state)
+
+    def __delitem__(self, key: str) -> None:
+        raise KeyError(key)
+
+    def __iter__(self):
+        return iter(self.plan.state())
+
+    def __len__(self) -> int:
+        return len(self.plan.state())

--- a/src/research_lab/retrieval_plan.py
+++ b/src/research_lab/retrieval_plan.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from research_lab.models import QueryRecord
+
+
+@dataclass(slots=True)
+class SourceBudget:
+    enabled: bool
+    requests_remaining: int
+
+    def can_use(self) -> bool:
+        return self.enabled and self.requests_remaining > 0
+
+    def consume(self) -> None:
+        self.requests_remaining -= 1
+
+    def disable(self) -> None:
+        self.enabled = False
+
+
+class RetrievalPlan:
+    def __init__(self, has_semantic_scholar_api_key: bool, scholar_per_query: int) -> None:
+        self.arxiv = SourceBudget(enabled=True, requests_remaining=6)
+        self.semantic_scholar = SourceBudget(
+            enabled=has_semantic_scholar_api_key,
+            requests_remaining=999 if has_semantic_scholar_api_key else 0,
+        )
+        self.google_scholar = SourceBudget(
+            enabled=scholar_per_query > 0,
+            requests_remaining=3 if scholar_per_query > 0 else 0,
+        )
+        self.has_semantic_scholar_api_key = has_semantic_scholar_api_key
+
+    def should_use_arxiv(self, query: QueryRecord) -> bool:
+        return self.arxiv.can_use() and query.origin not in {"author_expansion", "title_expansion"}
+
+    def should_use_semantic_scholar(self, query: QueryRecord | None) -> bool:
+        if not self.semantic_scholar.can_use():
+            return False
+        if self.has_semantic_scholar_api_key or query is None:
+            return True
+        return query.origin not in {"author_expansion", "title_expansion"}
+
+    def should_use_google_scholar(self, query: QueryRecord) -> bool:
+        return self.google_scholar.can_use() and query.origin not in {"author_expansion", "title_expansion"}
+
+    def state(self) -> dict[str, object]:
+        return {
+            "arxiv_enabled": self.arxiv.enabled,
+            "arxiv_requests_remaining": self.arxiv.requests_remaining,
+            "semanticscholar_enabled": self.semantic_scholar.enabled,
+            "semanticscholar_has_api_key": self.has_semantic_scholar_api_key,
+            "semanticscholar_requests_remaining": self.semantic_scholar.requests_remaining,
+            "googlescholar_enabled": self.google_scholar.enabled,
+            "googlescholar_requests_remaining": self.google_scholar.requests_remaining,
+        }
+
+    def load_state(self, state: dict[str, object]) -> None:
+        self.arxiv.enabled = bool(state["arxiv_enabled"])
+        self.arxiv.requests_remaining = int(state["arxiv_requests_remaining"])
+        self.has_semantic_scholar_api_key = bool(state["semanticscholar_has_api_key"])
+        self.semantic_scholar.enabled = bool(state["semanticscholar_enabled"])
+        self.semantic_scholar.requests_remaining = int(state["semanticscholar_requests_remaining"])
+        self.google_scholar.enabled = bool(state["googlescholar_enabled"])
+        self.google_scholar.requests_remaining = int(state["googlescholar_requests_remaining"])

--- a/src/research_lab/search_session.py
+++ b/src/research_lab/search_session.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+from research_lab.enrichment import enrich_candidates
+from research_lab.final_ranking import finalize_ranking
+from research_lab.identity import candidates_match
+from research_lab.models import Candidate, QueryRecord, ResearchBrief, RunArtifacts
+from research_lab.planner import build_expansion_queries, build_seed_queries
+from research_lab.rank import dedupe_candidates, rank_candidates
+from research_lab.report import write_run_files
+from research_lab.retrieval import RetrievalPolicy
+from research_lab.sources import HttpClient
+from research_lab.store import init_db, record_run
+
+
+class SearchSession:
+    def __init__(self, brief: ResearchBrief, client: HttpClient | None = None) -> None:
+        self.brief = brief
+        self.client = client or HttpClient()
+        self.retrieval = RetrievalPolicy(client=self.client, scholar_per_query=brief.scholar_per_query)
+        self.queries: list[QueryRecord] = []
+        self.pool: list[Candidate] = []
+        self._seen_query_strings: set[str] = set()
+
+    @property
+    def warnings(self) -> list[str]:
+        return self.retrieval.warnings
+
+    def execute(self, run_id: str, run_dir: Path, db_path: Path, program_text: str) -> RunArtifacts:
+        self._run_seed_queries()
+        ranked = self._rank_pool()
+
+        for iteration in range(1, self.brief.iterations + 1):
+            ranked = self._run_expansion_iteration(ranked, iteration)
+
+        final_ranking = self._finalize_ranking(ranked)
+        artifacts = RunArtifacts.create(
+            run_id=run_id,
+            run_dir=str(run_dir),
+            brief=self.brief,
+            queries=self.queries,
+            candidates=final_ranking.ranked,
+            program_text=program_text,
+            warnings=sorted(set(self.warnings)),
+            synthesis=final_ranking.synthesis,
+        )
+        write_run_files(run_dir, artifacts)
+        init_db(db_path)
+        record_run(db_path, artifacts)
+        return artifacts
+
+    def _run_seed_queries(self) -> None:
+        for query in build_seed_queries(self.brief):
+            self._record_query(query)
+            self.pool.extend(self.retrieval.search(query, self.brief))
+
+    def _run_expansion_iteration(self, ranked: list[Candidate], iteration: int) -> list[Candidate]:
+        seed_candidates = expansion_seed_candidates(ranked, self.brief)
+        top_titles = [candidate.title for candidate in seed_candidates[:3]]
+        top_authors = top_candidate_authors(seed_candidates)
+        expanded_pool: list[Candidate] = []
+
+        for query in build_expansion_queries(self.brief, top_titles, top_authors, iteration):
+            if not self._record_query(query):
+                continue
+            expanded_pool.extend(self.retrieval.search(query, self.brief))
+
+        for candidate in seed_candidates[:2]:
+            expanded_pool.extend(self.retrieval.fetch_references(candidate, self.brief.per_query))
+
+        if not expanded_pool:
+            return ranked
+        self.pool.extend(expanded_pool)
+        return self._rank_pool()
+
+    def _finalize_ranking(self, ranked: list[Candidate]):
+        enriched, enrichment_warnings = enrich_candidates(ranked[: self.brief.full_text_top_n], self.brief, self.client)
+        self.warnings.extend(enrichment_warnings)
+        self.pool.extend(enriched)
+        deduped_pool = dedupe_candidates(self.pool)
+        reranked = rank_candidates(deduped_pool, self.brief)
+        final_ranked = merge_scored_candidates(reranked, deduped_pool)
+        return finalize_ranking(final_ranked, self.brief, self.warnings)
+
+    def _rank_pool(self) -> list[Candidate]:
+        return rank_candidates(dedupe_candidates(self.pool), self.brief)
+
+    def _record_query(self, query: QueryRecord) -> bool:
+        lowered = query.query.lower()
+        if lowered in self._seen_query_strings:
+            return False
+        self._seen_query_strings.add(lowered)
+        self.queries.append(query)
+        return True
+
+
+def top_candidate_authors(candidates: list[Candidate]) -> list[str]:
+    counts = Counter(author for candidate in candidates for author in candidate.authors[:3] if author)
+    return [author for author, _ in counts.most_common(3)]
+
+
+def merge_scored_candidates(ranked: list[Candidate], pool: list[Candidate]) -> list[Candidate]:
+    merged: list[Candidate] = []
+    used_indices: set[int] = set()
+    for scored_candidate in ranked:
+        for index, candidate in enumerate(pool):
+            if index in used_indices:
+                continue
+            if not candidates_match(scored_candidate, candidate):
+                continue
+            candidate.score = scored_candidate.score
+            candidate.reasons = list(scored_candidate.reasons)
+            candidate.flags = list(scored_candidate.flags)
+            merged.append(candidate)
+            used_indices.add(index)
+            break
+    return merged
+
+
+def expansion_seed_candidates(ranked: list[Candidate], brief: ResearchBrief) -> list[Candidate]:
+    required_hits = 0
+    if brief.must_include:
+        required_hits = 1 if len(brief.must_include) <= 2 else 2
+
+    filtered = [
+        candidate
+        for candidate in ranked
+        if candidate.document_kind == "paper"
+        and candidate.score >= 0.45
+        and must_include_hits(candidate, brief) >= required_hits
+        and not any(flag in {"drift", "weak_title"} for flag in candidate.flags)
+    ]
+    if filtered:
+        return filtered[:3]
+
+    papers = [candidate for candidate in ranked if candidate.document_kind == "paper"]
+    if papers:
+        return papers[:3]
+    return ranked[:3]
+
+
+def must_include_hits(candidate: Candidate, brief: ResearchBrief) -> int:
+    searchable_text = f"{candidate.title} {candidate.abstract} {candidate.snippet}".lower()
+    return sum(1 for term in brief.must_include if term.lower() in searchable_text)

--- a/src/research_lab/source_candidates.py
+++ b/src/research_lab/source_candidates.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from research_lab.models import Candidate
+
+
+def paper_candidate(
+    *,
+    title: str,
+    abstract: str,
+    url: str,
+    source: str,
+    source_id: str,
+    authors: list[str] | None = None,
+    year: int | None = None,
+    venue: str = "",
+    doi: str = "",
+    citation_count: int = 0,
+    open_access_url: str = "",
+    snippet: str = "",
+    fields_of_study: list[str] | None = None,
+) -> Candidate:
+    return Candidate(
+        title=title,
+        abstract=abstract,
+        url=url,
+        source=source,
+        source_id=source_id,
+        authors=authors or [],
+        year=year,
+        venue=venue,
+        doi=doi,
+        citation_count=citation_count,
+        open_access_url=open_access_url,
+        snippet=snippet or abstract,
+        fields_of_study=fields_of_study or [],
+        source_names=[source],
+    )
+
+
+def web_candidate(*, title: str, abstract: str, url: str, source: str, source_id: str, venue: str = "") -> Candidate:
+    return Candidate(
+        title=title,
+        abstract=abstract,
+        url=url,
+        source=source,
+        source_id=source_id,
+        venue=venue,
+        document_kind="web",
+        snippet=abstract,
+        source_names=[source],
+    )

--- a/src/research_lab/sources/arxiv.py
+++ b/src/research_lab/sources/arxiv.py
@@ -4,6 +4,7 @@ import urllib.parse
 import xml.etree.ElementTree as ET
 
 from research_lab.models import Candidate
+from research_lab.source_candidates import paper_candidate
 from research_lab.sources.extraction import _clean_text, _extract_year
 from research_lab.sources.transport import HttpClient, SourceError
 
@@ -37,7 +38,7 @@ def search_arxiv(query: str, limit: int, since_year: int | None, client: HttpCli
                 pdf_url = link.attrib.get("href", "")
                 break
         results.append(
-            Candidate(
+            paper_candidate(
                 title=title,
                 abstract=abstract,
                 url=paper_url,
@@ -49,7 +50,6 @@ def search_arxiv(query: str, limit: int, since_year: int | None, client: HttpCli
                 doi=_clean_text(entry.findtext("arxiv:doi", default="", namespaces=namespace)),
                 open_access_url=pdf_url,
                 snippet=abstract,
-                source_names=["arxiv"],
             )
         )
         if len(results) >= limit:

--- a/src/research_lab/sources/duckduckgo.py
+++ b/src/research_lab/sources/duckduckgo.py
@@ -4,6 +4,7 @@ from html.parser import HTMLParser
 import urllib.parse
 
 from research_lab.models import Candidate
+from research_lab.source_candidates import web_candidate
 from research_lab.sources.extraction import _clean_text
 from research_lab.sources.transport import HttpClient
 
@@ -79,16 +80,13 @@ def search_duckduckgo(query: str, limit: int, client: HttpClient) -> list[Candid
     parser.feed(response.body.decode("utf-8", errors="ignore"))
     parser.close()
     return [
-        Candidate(
+        web_candidate(
             title=item["title"],
             abstract=item["snippet"],
             url=item["url"],
             source="duckduckgo",
             source_id=item["url"],
             venue=_url_host(item["url"]),
-            document_kind="web",
-            snippet=item["snippet"],
-            source_names=["duckduckgo"],
         )
         for item in parser.results[:limit]
     ]

--- a/src/research_lab/sources/extraction.py
+++ b/src/research_lab/sources/extraction.py
@@ -124,33 +124,9 @@ def _classify_html_access(candidate: Candidate, response: HttpResponse) -> FullT
 
 
 def fetch_candidate_full_text(candidate: Candidate, client: HttpClient) -> FullTextResult:
-    last_result = FullTextResult(text="", source="", access_status="", access_url="")
-    last_error: SourceError | None = None
-    for url in [candidate.open_access_url, candidate.url]:
-        if not url:
-            continue
-        try:
-            response = client.fetch(url, headers={"Accept": "text/html,application/pdf;q=0.9,*/*;q=0.8"})
-        except SourceError as exc:
-            last_result = _classify_fetch_error(url, exc)
-            last_error = exc
-            continue
-        content_type = response.content_type.lower()
-        if "pdf" in content_type or response.final_url.lower().endswith(".pdf") or url.lower().endswith(".pdf"):
-            text = _extract_text_from_pdf_bytes(response.body)
-            if text:
-                return FullTextResult(text=text, source="pdf", access_status="open", access_url=response.final_url)
-            last_result = FullTextResult(text="", source="", access_status="unreadable", access_url=response.final_url)
-            continue
-        result = _classify_html_access(candidate, response)
-        if result.text:
-            return result
-        last_result = result
-    if last_result.access_status:
-        return last_result
-    if last_error is not None:
-        raise last_error
-    raise SourceError(f"no reachable content found for {candidate.title}")
+    from research_lab.document_access import DocumentAccessResolver
+
+    return DocumentAccessResolver(client).fetch(candidate)
 
 
 def _extract_text_from_html(html: str) -> str:

--- a/src/research_lab/sources/googlescholar.py
+++ b/src/research_lab/sources/googlescholar.py
@@ -5,6 +5,7 @@ import re
 import urllib.parse
 
 from research_lab.models import Candidate
+from research_lab.source_candidates import paper_candidate
 from research_lab.sources.extraction import _clean_text, _extract_year
 from research_lab.sources.transport import HttpClient, SourceError
 
@@ -145,7 +146,7 @@ def search_google_scholar(query: str, limit: int, client: HttpClient) -> list[Ca
     parser.feed(html)
     parser.close()
     return [
-        Candidate(
+        paper_candidate(
             title=_clean_scholar_title(item["title"]),
             abstract=item["snippet"],
             url=item["url"],
@@ -156,7 +157,6 @@ def search_google_scholar(query: str, limit: int, client: HttpClient) -> list[Ca
             venue=_parse_scholar_venue(item["meta"], _extract_year(item["meta"])),
             open_access_url=item.get("open_access_url", ""),
             snippet=item["snippet"],
-            source_names=["googlescholar"],
         )
         for item in parser.results[:limit]
     ]

--- a/src/research_lab/sources/openalex.py
+++ b/src/research_lab/sources/openalex.py
@@ -4,6 +4,7 @@ import os
 import urllib.parse
 
 from research_lab.models import Candidate
+from research_lab.source_candidates import paper_candidate
 from research_lab.sources.transport import HttpClient
 
 
@@ -46,10 +47,11 @@ def search_openalex(query: str, per_page: int, since_year: int | None, client: H
         primary_location = item.get("primary_location") or {}
         oa_location = item.get("best_oa_location") or {}
         authorships = item.get("authorships") or []
+        abstract = _join_abstract(item.get("abstract_inverted_index"))
         results.append(
-            Candidate(
+            paper_candidate(
                 title=item.get("title") or "",
-                abstract=_join_abstract(item.get("abstract_inverted_index")),
+                abstract=abstract,
                 url=(primary_location.get("landing_page_url") or item.get("id") or ""),
                 source="openalex",
                 source_id=item.get("id") or "",
@@ -59,9 +61,8 @@ def search_openalex(query: str, per_page: int, since_year: int | None, client: H
                 doi=_extract_doi(item.get("doi")),
                 citation_count=item.get("cited_by_count") or 0,
                 open_access_url=oa_location.get("pdf_url") or "",
-                snippet=_join_abstract(item.get("abstract_inverted_index")),
+                snippet=abstract,
                 fields_of_study=[topic.get("display_name", "") for topic in item.get("topics") or []],
-                source_names=["openalex"],
             )
         )
     return results

--- a/src/research_lab/sources/semanticscholar.py
+++ b/src/research_lab/sources/semanticscholar.py
@@ -4,6 +4,7 @@ import os
 import urllib.parse
 
 from research_lab.models import Candidate
+from research_lab.source_candidates import paper_candidate
 from research_lab.sources.transport import HttpClient
 
 
@@ -22,10 +23,11 @@ def search_semantic_scholar(query: str, limit: int, since_year: int | None, clie
     for item in payload.get("data", []):
         external_ids = item.get("externalIds") or {}
         open_access_pdf = item.get("openAccessPdf") or {}
+        abstract = item.get("abstract") or ""
         results.append(
-            Candidate(
+            paper_candidate(
                 title=item.get("title") or "",
-                abstract=item.get("abstract") or "",
+                abstract=abstract,
                 url=item.get("url") or "",
                 source="semanticscholar",
                 source_id=item.get("paperId") or "",
@@ -35,9 +37,8 @@ def search_semantic_scholar(query: str, limit: int, since_year: int | None, clie
                 doi=external_ids.get("DOI") or "",
                 citation_count=item.get("citationCount") or 0,
                 open_access_url=open_access_pdf.get("url") or "",
-                snippet=item.get("abstract") or "",
+                snippet=abstract,
                 fields_of_study=item.get("fieldsOfStudy") or [],
-                source_names=["semanticscholar"],
             )
         )
     return results
@@ -62,10 +63,11 @@ def fetch_semantic_scholar_references(paper_id: str, limit: int, client: HttpCli
         cited = item.get("citedPaper") or item
         external_ids = cited.get("externalIds") or {}
         open_access_pdf = cited.get("openAccessPdf") or {}
+        abstract = cited.get("abstract") or ""
         results.append(
-            Candidate(
+            paper_candidate(
                 title=cited.get("title") or "",
-                abstract=cited.get("abstract") or "",
+                abstract=abstract,
                 url=cited.get("url") or "",
                 source="semanticscholar_reference",
                 source_id=cited.get("paperId") or "",
@@ -75,9 +77,8 @@ def fetch_semantic_scholar_references(paper_id: str, limit: int, client: HttpCli
                 doi=external_ids.get("DOI") or "",
                 citation_count=cited.get("citationCount") or 0,
                 open_access_url=open_access_pdf.get("url") or "",
-                snippet=cited.get("abstract") or "",
+                snippet=abstract,
                 fields_of_study=cited.get("fieldsOfStudy") or [],
-                source_names=["semanticscholar_reference"],
             )
         )
     return results

--- a/tests/test_document_access.py
+++ b/tests/test_document_access.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from research_lab.document_access import DocumentAccessResolver
+from research_lab.models import PaperCandidate
+from research_lab.sources import HttpResponse, SourceError
+
+
+class _FakeClient:
+    def __init__(self, responses: dict[str, HttpResponse | Exception]) -> None:
+        self.responses = responses
+
+    def fetch(self, url: str, headers: dict[str, str] | None = None) -> HttpResponse:
+        del headers
+        response = self.responses[url]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class DocumentAccessResolverTests(unittest.TestCase):
+    def test_fetch_falls_back_from_open_access_url_to_landing_page(self) -> None:
+        candidate = PaperCandidate(
+            title="Fallback Paper",
+            abstract="",
+            url="https://example.com/landing",
+            source="openalex",
+            source_id="oa:1",
+            open_access_url="https://example.com/missing.pdf",
+            document_kind="paper",
+            source_names=["openalex"],
+        )
+        html = b"""
+        <html><body>
+          <h1>Fallback Paper</h1>
+          <h2>Introduction</h2>
+          <p>This paper includes readable full text content.</p>
+          <h2>Methods</h2><p>Method text.</p>
+          <h2>Results</h2><p>Result text.</p>
+          <h2>References</h2><p>Refs.</p>
+        </body></html>
+        """
+        client = _FakeClient(
+            {
+                "https://example.com/missing.pdf": SourceError("request failed for https://example.com/missing.pdf: HTTP Error 404:"),
+                "https://example.com/landing": HttpResponse(
+                    body=html,
+                    content_type="text/html",
+                    final_url="https://example.com/landing",
+                ),
+            }
+        )
+
+        result = DocumentAccessResolver(client).fetch(candidate)
+
+        self.assertEqual(result.access_status, "open")
+        self.assertEqual(result.source, "html")
+        self.assertTrue(result.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from research_lab.engine import _expansion_seed_candidates
 from research_lab.models import PaperCandidate, QueryRecord, ResearchBrief
+from research_lab.retrieval_plan import RetrievalPlan
 from research_lab.retrieval import RetrievalPolicy
 from research_lab.search_session import SearchSession
 from research_lab.sources import HttpClient, HttpResponse, SourceError
@@ -32,6 +33,14 @@ class _FakeClient(HttpClient):
 
 
 class EngineTests(unittest.TestCase):
+    def test_retrieval_plan_skips_low_value_expansions_without_api_key(self) -> None:
+        plan = RetrievalPlan(has_semantic_scholar_api_key=False, scholar_per_query=1)
+        plan.semantic_scholar.enabled = True
+        plan.semantic_scholar.requests_remaining = 5
+        query = QueryRecord(query='"Jane Doe" graph neural networks', origin="author_expansion", iteration=1)
+
+        self.assertFalse(plan.should_use_semantic_scholar(query))
+
     def test_search_session_records_unique_queries(self) -> None:
         brief = ResearchBrief(topic="graph neural networks", context="")
         session = SearchSession(brief)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from research_lab.engine import _expansion_seed_candidates
 from research_lab.models import PaperCandidate, QueryRecord, ResearchBrief
 from research_lab.retrieval import RetrievalPolicy
+from research_lab.search_session import SearchSession
 from research_lab.sources import HttpClient, HttpResponse, SourceError
 
 
@@ -31,6 +32,18 @@ class _FakeClient(HttpClient):
 
 
 class EngineTests(unittest.TestCase):
+    def test_search_session_records_unique_queries(self) -> None:
+        brief = ResearchBrief(topic="graph neural networks", context="")
+        session = SearchSession(brief)
+        query = QueryRecord(query="graph neural networks", origin="topic", iteration=0)
+
+        first = session._record_query(query)
+        second = session._record_query(query)
+
+        self.assertTrue(first)
+        self.assertFalse(second)
+        self.assertEqual(session.queries, [query])
+
     def test_expansion_seed_candidates_prefer_clean_papers(self) -> None:
         brief = ResearchBrief(topic="mixed precision training", context="", must_include=["mixed precision", "float16", "loss scaling"])
         web = PaperCandidate(

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -6,10 +6,21 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from research_lab.enrichment import extract_evidence_sentences
 from research_lab.models import PaperCandidate, ResearchBrief
-from research_lab.rank import dedupe_candidates, rank_candidates
+from research_lab.rank import _score_constraints, dedupe_candidates, rank_candidates
 
 
 class RankTests(unittest.TestCase):
+    def test_score_constraints_sets_drift_flag(self) -> None:
+        brief = ResearchBrief(topic="test-time adaptation for language models", context="")
+        topic_terms = {"test-time", "adaptation", "language", "models"}
+        text_terms = {"robotic", "language", "model", "adaptation", "manipulation"}
+
+        score, reasons, flags = _score_constraints(brief, topic_terms, text_terms, "robotic language model adaptation")
+
+        self.assertLess(score, 0)
+        self.assertTrue(any("drift" in reason for reason in reasons))
+        self.assertIn("drift", flags)
+
     def test_dedupe_prefers_richer_candidate(self) -> None:
         first = PaperCandidate(
             title="A Useful Paper",

--- a/tests/test_source_candidates.py
+++ b/tests/test_source_candidates.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from research_lab.source_candidates import paper_candidate, web_candidate
+
+
+class SourceCandidateTests(unittest.TestCase):
+    def test_paper_candidate_uses_source_name_and_snippet_defaults(self) -> None:
+        candidate = paper_candidate(
+            title="A Paper",
+            abstract="Abstract text",
+            url="https://example.com/paper",
+            source="openalex",
+            source_id="oa:1",
+        )
+
+        self.assertEqual(candidate.document_kind, "paper")
+        self.assertEqual(candidate.snippet, "Abstract text")
+        self.assertEqual(candidate.source_names, ["openalex"])
+
+    def test_web_candidate_marks_document_kind(self) -> None:
+        candidate = web_candidate(
+            title="A Web Result",
+            abstract="Snippet text",
+            url="https://example.com/web",
+            source="duckduckgo",
+            source_id="web:1",
+            venue="example.com",
+        )
+
+        self.assertEqual(candidate.document_kind, "web")
+        self.assertEqual(candidate.snippet, "Snippet text")
+        self.assertEqual(candidate.source_names, ["duckduckgo"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR deepens several shallow modules in the literature-search laboratory so behavior is concentrated behind smaller, more testable seams:

- adds `SearchSession` to own one run's query ledger, pool growth, expansion loop, and finalization
- adds `RetrievalPlan` / `SourceBudget` to absorb source enablement, request budgets, and fallback gating
- adds shared candidate normalization helpers for source adapters
- adds `DocumentAccessResolver` to concentrate full-text fetch and access classification
- splits ranking internals into named signals while keeping the external ranking seam stable

The work was pushed as atomic commits so each refactor slice can be reviewed independently.

## Tests run

- `uv run --group dev pytest`