### PR TITLE
fix(ci): pass GitHub token to opencode

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -23,8 +23,10 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     permissions:
-      contents: read
+      contents: write
       id-token: write
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -41,6 +43,8 @@ jobs:
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest
         env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           SIEMENS_LLM_API_KEY: ${{ secrets.SIEMENS_LLM_API_KEY }}
           OPENCODE_CONFIG_CONTENT: |
             {


### PR DESCRIPTION
## Summary
- pass the workflow token into the OpenCode action as both `GITHUB_TOKEN` and `GH_TOKEN`
- grant the issue-comment workflow `contents: write`, `issues: write`, and `pull-requests: write`
- allow `/oc` runs to close issues and perform other `gh`-based repo actions directly

## Tests run
- not run (workflow/config change only)
- verified `.github/workflows/opencode.yml` now exposes the token and required write permissions

Closes #42