### PR TITLE
fix(ci): keep README issue index in sync

### DIFF
--- a/.github/workflows/update-readme-issues.yml
+++ b/.github/workflows/update-readme-issues.yml
@@ -22,7 +22,7 @@ permissions:
 
 concurrency:
   group: update-readme-issues
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   update-readme:
@@ -107,4 +107,5 @@ jobs:
           GIT_COMMITTER_NAME="github-actions[bot]" \
           GIT_COMMITTER_EMAIL="41898282+github-actions[bot]@users.noreply.github.com" \
           git commit -m "docs(readme): update issue index"
+          git pull --rebase origin HEAD
           git push

--- a/README.md
+++ b/README.md
@@ -225,5 +225,5 @@ If you run OpenCode inside this repo, there are prompt files under `.opencode/ag
 ## Issues
 
 <!-- issues:start -->
-- [#44](https://github.com/kovacoj/research-lab/issues/44) node js deprecacy warning
+- [#47](https://github.com/kovacoj/research-lab/issues/47) closed issue present in the README as an active issue
 <!-- issues:end -->


### PR DESCRIPTION
## Summary
- prevent `update-readme-issues` close-event runs from being canceled by other in-flight runs
- rebase generated README changes before pushing to reduce concurrent update failures
- refresh the checked-in README issue block so it matches the current open issue list

## Tests run
- `gh issue list --state open --limit 200 --json number,title,url`
- `git diff --check`

Closes #47