### PR TITLE
chore(ci): pin opencode action release

### DIFF
--- a/.github/workflows/opencode-main-review.yml
+++ b/.github/workflows/opencode-main-review.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ inputs.after_sha }}
 
       - name: Run OpenCode review
-        uses: anomalyco/opencode/github@latest
+        uses: anomalyco/opencode/github@v1.14.41
         env:
           SIEMENS_LLM_API_KEY: ${{ secrets.SIEMENS_LLM_API_KEY }}
           OPENCODE_CONFIG_CONTENT: |

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -41,7 +41,7 @@ jobs:
           git config --global user.email "219766164+opencode-agent[bot]@users.noreply.github.com"
 
       - name: Run OpenCode
-        uses: anomalyco/opencode/github@latest
+        uses: anomalyco/opencode/github@v1.14.41
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- pin `anomalyco/opencode/github` from `@latest` to `@v1.14.41` in the main OpenCode workflow
- pin the same action version in the tag review workflow to keep behavior consistent

## Tests run
- Not run; workflow reference change only