### PR TITLE
fix(ci): tolerate missing review findings

### DIFF
--- a/.github/workflows/opencode-pr-review.yml
+++ b/.github/workflows/opencode-pr-review.yml
@@ -250,7 +250,13 @@ jobs:
               f"{os.environ['GITHUB_SERVER_URL']}/{repo}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
           )
 
-          findings_doc = json.loads(findings_path.read_text(encoding="utf-8"))
+          if not findings_path.exists():
+              findings_doc = {"summary": "", "findings": []}
+          else:
+              try:
+                  findings_doc = json.loads(findings_path.read_text(encoding="utf-8"))
+              except json.JSONDecodeError:
+                  findings_doc = {"summary": "", "findings": []}
           changed_lines = json.loads(changed_lines_path.read_text(encoding="utf-8"))
 
           findings = findings_doc.get("findings") or []


### PR DESCRIPTION
## Summary
- treat a missing `findings.json` file as an empty review result
- fall back to an empty findings list when OpenCode emits malformed JSON
- keep the PR review workflow from failing on model formatting issues

## Tests run
- `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/opencode-pr-review.yml').read_text()); print('YAML OK')"`