### PR TITLE
fix(ci): use app token for PR reviews

### DIFF
--- a/.github/workflows/opencode-pr-review.yml
+++ b/.github/workflows/opencode-pr-review.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           client-id: ${{ vars.GLM5_REVIEWER_APP_CLIENT_ID }}
           private-key: ${{ secrets.GLM5_REVIEWER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: research-lab
           permission-contents: read
           permission-pull-requests: write
 

--- a/.github/workflows/opencode-pr-review.yml
+++ b/.github/workflows/opencode-pr-review.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
   pull-requests: write
 
 concurrency:
@@ -39,6 +38,15 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Create GLM-5 reviewer bot token
+        id: glm5-reviewer-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.GLM5_REVIEWER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GLM5_REVIEWER_APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: write
+
       - name: Install OpenCode
         run: curl -fsSL https://opencode.ai/install | bash
 
@@ -47,7 +55,7 @@ jobs:
 
       - name: Prepare PR review context
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.glm5-reviewer-token.outputs.token }}
         run: |
           mkdir -p "$REVIEW_DIR"
           python3 <<'PY'
@@ -142,7 +150,7 @@ jobs:
 
       - name: Remove previous OpenCode review comments
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.glm5-reviewer-token.outputs.token }}
         run: |
           python3 <<'PY'
           import json
@@ -226,7 +234,7 @@ jobs:
 
       - name: Publish inline review comments
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.glm5-reviewer-token.outputs.token }}
         run: |
           python3 <<'PY'
           import json


### PR DESCRIPTION
## Summary
- generate a GitHub App installation token in the PR review workflow
- use the app token for PR review API calls instead of `GITHUB_TOKEN`
- remove the now-unused `id-token: write` permission

## Tests run
- `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/opencode-pr-review.yml').read_text()); print('YAML OK')"`