### PR TITLE
fix(ci): surface PR review results

### DIFF
--- a/.github/workflows/opencode-pr-review.yml
+++ b/.github/workflows/opencode-pr-review.yml
@@ -304,16 +304,23 @@ jobs:
                   body = resp.read().decode("utf-8")
               return json.loads(body) if body else None
 
-          for finding in valid:
+          if valid:
               request(
                   "POST",
-                  f"https://api.github.com/repos/{repo}/pulls/{pr_number}/comments",
+                  f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews",
                   {
-                      "body": f"{marker}\n{finding['body']}",
                       "commit_id": head_sha,
-                      "path": finding["path"],
-                      "line": finding["line"],
-                      "side": "RIGHT",
+                      "event": "COMMENT",
+                      "body": "OpenCode found material issues. See inline comments.",
+                      "comments": [
+                          {
+                              "body": f"{marker}\n{finding['body']}",
+                              "path": finding["path"],
+                              "line": finding["line"],
+                              "side": "RIGHT",
+                          }
+                          for finding in valid
+                      ],
                   },
               )
 

--- a/.github/workflows/opencode-pr-review.yml
+++ b/.github/workflows/opencode-pr-review.yml
@@ -1,5 +1,7 @@
 name: opencode-pr-review
 
+run-name: OpenCode review PR #${{ github.event.pull_request.number }}
+
 on:
   pull_request:
     types:
@@ -29,6 +31,7 @@ jobs:
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       REVIEW_DIR: .github/opencode-pr-review
       REVIEW_MARKER: <!-- opencode-pr-review -->
+      REVIEW_SUMMARY_MARKER: <!-- opencode-pr-review-summary -->
 
     steps:
       - name: Checkout repository
@@ -47,6 +50,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: research-lab
           permission-contents: read
+          permission-issues: write
           permission-pull-requests: write
 
       - name: Install OpenCode
@@ -249,10 +253,14 @@ jobs:
           head_sha = os.environ["HEAD_SHA"]
           token = os.environ["GH_TOKEN"]
           marker = os.environ["REVIEW_MARKER"]
+          summary_marker = os.environ["REVIEW_SUMMARY_MARKER"]
           review_dir = pathlib.Path(os.environ["REVIEW_DIR"])
           findings_path = review_dir / "findings.json"
           changed_lines_path = review_dir / "changed-lines.json"
           summary_path = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
+          run_url = (
+              f"{os.environ['GITHUB_SERVER_URL']}/{repo}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+          )
 
           if not findings_path.exists():
               findings_doc = {"summary": "", "findings": []}
@@ -307,6 +315,33 @@ jobs:
                       "line": finding["line"],
                       "side": "RIGHT",
                   },
+              )
+
+          summary_body_lines = [summary_marker, "OpenCode PR review completed."]
+          if valid:
+              summary_body_lines.append(f"- Inline comments posted: {len(valid)}")
+          else:
+              summary_body_lines.append("- No material findings were posted as inline comments.")
+          if skipped:
+              summary_body_lines.append(f"- Findings skipped after validation: {len(skipped)}")
+          summary_body_lines.append(f"- [Workflow run]({run_url})")
+          summary_body = "\n".join(summary_body_lines)
+
+          comments = request(
+              "GET",
+              f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments?per_page=100",
+          )
+          existing_summary = next(
+              (comment for comment in comments if summary_marker in (comment.get("body") or "")),
+              None,
+          )
+          if existing_summary:
+              request("PATCH", existing_summary["url"], {"body": summary_body})
+          else:
+              request(
+                  "POST",
+                  f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments",
+                  {"body": summary_body},
               )
 
           summary_lines = [


### PR DESCRIPTION
## Summary
- restore a sticky PR summary comment for the automatic review workflow
- grant the review app token issue-comment permission so it can post that summary
- keep inline comments only for validated material findings

## Tests run
- `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/opencode-pr-review.yml').read_text()); print('YAML OK')"`