### PR TITLE
fix(ci): skip redundant review summary

### DIFF
--- a/.github/workflows/opencode-pr-review.yml
+++ b/.github/workflows/opencode-pr-review.yml
@@ -258,9 +258,6 @@ jobs:
           findings_path = review_dir / "findings.json"
           changed_lines_path = review_dir / "changed-lines.json"
           summary_path = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
-          run_url = (
-              f"{os.environ['GITHUB_SERVER_URL']}/{repo}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
-          )
 
           if not findings_path.exists():
               findings_doc = {"summary": "", "findings": []}
@@ -324,16 +321,6 @@ jobs:
                   },
               )
 
-          summary_body_lines = [summary_marker, "OpenCode PR review completed."]
-          if valid:
-              summary_body_lines.append(f"- Inline comments posted: {len(valid)}")
-          else:
-              summary_body_lines.append("- No material findings were posted as inline comments.")
-          if skipped:
-              summary_body_lines.append(f"- Findings skipped after validation: {len(skipped)}")
-          summary_body_lines.append(f"- [Workflow run]({run_url})")
-          summary_body = "\n".join(summary_body_lines)
-
           comments = request(
               "GET",
               f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments?per_page=100",
@@ -342,14 +329,22 @@ jobs:
               (comment for comment in comments if summary_marker in (comment.get("body") or "")),
               None,
           )
-          if existing_summary:
-              request("PATCH", existing_summary["url"], {"body": summary_body})
+          if valid:
+              if existing_summary:
+                  request("DELETE", existing_summary["url"])
           else:
-              request(
-                  "POST",
-                  f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments",
-                  {"body": summary_body},
-              )
+              summary_body_lines = [summary_marker, "OpenCode found no material issues."]
+              if skipped:
+                  summary_body_lines.append(f"- Findings skipped after validation: {len(skipped)}")
+              summary_body = "\n".join(summary_body_lines)
+              if existing_summary:
+                  request("PATCH", existing_summary["url"], {"body": summary_body})
+              else:
+                  request(
+                      "POST",
+                      f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments",
+                      {"body": summary_body},
+                  )
 
           summary_lines = [
               "## OpenCode PR Review",


### PR DESCRIPTION
## Summary
- stop posting the sticky PR summary comment when inline findings already exist
- keep the no-findings comment only for clean review runs
- delete stale no-findings summary comments on reruns that later produce findings

## Tests run
- `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/opencode-pr-review.yml').read_text()); print('YAML OK')"`